### PR TITLE
owners_can_edit and owners_can_delete config options, FileSourceResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,16 @@ plugins:
 
 All access is **denied by default**. You must explicitly grant permissions in the `permissions:` block of your `datasette.yaml`.
 
-There are four permission actions, each scoped to a source:
+There are four permission actions:
 
-| Action | Description |
-|--------|-------------|
-| `files-browse` | Browse, search, view, and download files |
-| `files-upload` | Upload files to a source |
-| `files-edit` | Edit file metadata (e.g. search text) |
-| `files-delete` | Delete files from a source |
+| Action | Description | Scoped to |
+|--------|-------------|-----------|
+| `files-browse` | Browse, search, view, and download files | Source |
+| `files-upload` | Upload files to a source | Source |
+| `files-edit` | Edit file metadata (e.g. search text) | File |
+| `files-delete` | Delete files from a source | File |
+
+`files-browse` and `files-upload` are scoped to a source — granting them allows the action on all files in that source. `files-edit` and `files-delete` are scoped to individual files, but a source-level grant cascades to all files within it.
 
 CSV/TSV import also requires Datasette's built-in `create-table` and `insert-row` permissions on the target database. See [Built-in CSV import action](#built-in-csv-import-action) for details.
 
@@ -100,6 +102,26 @@ permissions:
       allow:
         id: alice
 ```
+
+#### Owner permissions
+
+By default, anyone with `files-edit` or `files-delete` permission on a source can edit or delete any file in that source. You can restrict edit and delete so that users can only act on files they uploaded themselves:
+
+```yaml
+plugins:
+  datasette-files:
+    owners_can_edit: true
+    owners_can_delete: true
+    sources:
+      my-files:
+        storage: filesystem
+        config:
+          root: /data/uploads
+```
+
+With these settings, the uploader of each file gains edit or delete permission on their own files — without needing a source-level `files-edit` or `files-delete` grant. Actors who *do* have a source-level grant (e.g. admins) can still act on any file in that source.
+
+Files uploaded without an authenticated actor have no owner, so they can only be managed by actors with source-level grants.
 
 ### Uploading files
 
@@ -181,7 +203,7 @@ curl -X POST "http://localhost:8001/-/files/df-01j5.../-/delete" \
   -d '{}'
 ```
 
-Requires `files-delete` permission on the file's source.
+Requires `files-delete` permission on the file (or a source-level `files-delete` grant).
 
 Deletion also depends on the storage backend supporting `can_delete`.
 
@@ -193,7 +215,7 @@ curl -X POST "http://localhost:8001/-/files/df-01j5.../-/update" \
   -d '{"update": {"search_text": "Annual report 2025"}}'
 ```
 
-Requires `files-edit` permission on the file's source. Only `search_text` can be updated through this endpoint for now, and the response returns the updated file record.
+Requires `files-edit` permission on the file (or a source-level `files-edit` grant). Only `search_text` can be updated through this endpoint for now, and the response returns the updated file record.
 
 ### Viewing files
 

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -340,6 +340,24 @@ class FileSourceResource(Resource):
         return "SELECT slug AS parent, NULL AS child FROM datasette_files_sources"
 
 
+class FileResource(Resource):
+    """An individual file within a source."""
+
+    name = "file"
+    parent_class = FileSourceResource
+
+    def __init__(self, source_slug: str, file_id: str):
+        super().__init__(parent=source_slug, child=file_id)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None) -> str:
+        return """
+            SELECT s.slug AS parent, f.id AS child
+            FROM datasette_files f
+            JOIN datasette_files_sources s ON f.source_id = s.id
+        """
+
+
 @hookimpl
 def register_actions():
     return [
@@ -358,14 +376,14 @@ def register_actions():
         Action(
             name="files-edit",
             abbr="fe",
-            description="Edit file metadata in a source",
-            resource_class=FileSourceResource,
+            description="Edit file metadata",
+            resource_class=FileResource,
         ),
         Action(
             name="files-delete",
             abbr="fd",
-            description="Delete files from a source",
-            resource_class=FileSourceResource,
+            description="Delete files",
+            resource_class=FileResource,
         ),
     ]
 
@@ -451,6 +469,40 @@ def files_permission_resources_sql(datasette, actor, action):
     return PermissionSQL(
         sql="\nUNION ALL\n".join(rules),
         params=params,
+    )
+
+
+@hookimpl(specname="permission_resources_sql")
+def files_owner_permissions_sql(datasette, actor, action):
+    """Grant file owners edit/delete permission on their own files.
+
+    Enabled via plugin config:
+        plugins:
+          datasette-files:
+            owners_can_edit: true
+            owners_can_delete: true
+    """
+    if action not in ("files-edit", "files-delete"):
+        return None
+    if not actor or not actor.get("id"):
+        return None
+
+    plugin_config = datasette.plugin_config("datasette-files") or {}
+    if action == "files-edit" and not plugin_config.get("owners_can_edit"):
+        return None
+    if action == "files-delete" and not plugin_config.get("owners_can_delete"):
+        return None
+
+    return PermissionSQL(
+        sql="""
+            SELECT s.slug AS parent, f.id AS child,
+                   1 AS allow,
+                   'file owner' AS reason
+            FROM datasette_files f
+            JOIN datasette_files_sources s ON f.source_id = s.id
+            WHERE f.uploaded_by = :dfow_actor_id
+        """,
+        params={"dfow_actor_id": actor["id"]},
     )
 
 
@@ -950,7 +1002,7 @@ async def file_delete(request, datasette):
     # Check delete permission
     allowed = await datasette.allowed(
         action="files-delete",
-        resource=FileSourceResource(source_slug),
+        resource=FileResource(source_slug, file_id),
         actor=request.actor,
     )
     if not allowed:
@@ -989,7 +1041,7 @@ async def file_update(request, datasette):
     # Check edit permission
     allowed = await datasette.allowed(
         action="files-edit",
-        resource=FileSourceResource(source_slug),
+        resource=FileResource(source_slug, file_id),
         actor=request.actor,
     )
     if not allowed:

--- a/tests/test_owner_permissions.py
+++ b/tests/test_owner_permissions.py
@@ -1,0 +1,281 @@
+"""Tests for owner-based edit/delete permissions.
+
+When `owners_can_edit` or `owners_can_delete` is configured in datasette-files
+plugin settings, the user who uploaded a file gains edit/delete permission on
+that specific file — even without a blanket files-edit/files-delete grant.
+"""
+
+from collections import namedtuple
+
+from datasette.app import Datasette
+import json
+import pytest
+
+from conftest import _make_datasette, _upload_file
+
+
+def _make_owner_datasette(upload_dir, owners_can_edit=False, owners_can_delete=False):
+    """Create a Datasette with browse+upload for everyone, and owner permissions configured."""
+    sources = {
+        "test-uploads": {
+            "storage": "filesystem",
+            "config": {"root": upload_dir},
+        }
+    }
+    plugin_config = {"sources": sources}
+    if owners_can_edit:
+        plugin_config["owners_can_edit"] = True
+    if owners_can_delete:
+        plugin_config["owners_can_delete"] = True
+
+    return Datasette(
+        memory=True,
+        config={
+            "plugins": {"datasette-files": plugin_config},
+            "permissions": {
+                "files-browse": True,
+                "files-upload": True,
+            },
+        },
+    )
+
+
+async def _upload_as(ds, actor_id, filename="test.txt", content=b"hello"):
+    """Upload a file as a specific actor and return the file_id."""
+    cookies = {"ds_actor": ds.sign({"a": {"id": actor_id}}, "actor")}
+    prepare = await ds.client.post(
+        "/-/files/upload/test-uploads/-/prepare",
+        content=json.dumps(
+            {
+                "filename": filename,
+                "content_type": "text/plain",
+                "size": len(content),
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+        cookies=cookies,
+    )
+    assert prepare.status_code == 200, prepare.text
+    data = prepare.json()
+
+    upload = await ds.client.post(
+        data["upload_url"],
+        content=(
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="upload_token"\r\n'
+            b"\r\n" + data["upload_token"].encode() + b"\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="file"; filename="'
+            + filename.encode()
+            + b'"\r\n'
+            b"Content-Type: text/plain\r\n"
+            b"\r\n" + content + b"\r\n"
+            b"--boundary--\r\n"
+        ),
+        headers={"Content-Type": "multipart/form-data; boundary=boundary"},
+        cookies=cookies,
+    )
+    assert upload.status_code == 200, upload.text
+
+    complete = await ds.client.post(
+        "/-/files/upload/test-uploads/-/complete",
+        content=json.dumps({"upload_token": data["upload_token"]}),
+        headers={"Content-Type": "application/json"},
+        cookies=cookies,
+    )
+    assert complete.status_code == 201, complete.text
+    return complete.json()["file"]["id"]
+
+
+# --- FileResource action registration ---
+
+
+def test_file_resource_used_for_edit_and_delete():
+    """files-edit and files-delete should be registered against FileResource."""
+    from datasette_files import FileResource, FileSourceResource, register_actions
+
+    actions = {a.name: a for a in register_actions()}
+    assert actions["files-edit"].resource_class is FileResource
+    assert actions["files-delete"].resource_class is FileResource
+    assert actions["files-browse"].resource_class is FileSourceResource
+    assert actions["files-upload"].resource_class is FileSourceResource
+
+
+# --- Source-level permissions still cascade to files ---
+
+
+@pytest.mark.asyncio
+async def test_source_level_delete_permission_still_works(datasette_all_permissions):
+    """A source-level files-delete grant should still allow deleting any file."""
+    ds = datasette_all_permissions
+    data = await _upload_file(ds)
+    file_id = data["file_id"]
+
+    response = await ds.client.post(
+        f"/-/files/{file_id}/-/delete",
+        content=json.dumps({}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_source_level_edit_permission_still_works(datasette_all_permissions):
+    """A source-level files-edit grant should still allow editing any file."""
+    ds = datasette_all_permissions
+    data = await _upload_file(ds)
+    file_id = data["file_id"]
+
+    response = await ds.client.post(
+        f"/-/files/{file_id}/-/update",
+        content=json.dumps({"update": {"search_text": "updated"}}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+# --- Owner permission tests ---
+
+OwnerPermissionCase = namedtuple(
+    "OwnerPermissionCase",
+    (
+        "description",
+        "endpoint_path",
+        "body",
+        "owners_can_edit",
+        "owners_can_delete",
+        "actor",
+        "expect_status",
+    ),
+)
+
+OWNER_PERMISSION_CASES = (
+    OwnerPermissionCase(
+        description="Owner can delete their own file",
+        endpoint_path="/-/delete",
+        body={},
+        owners_can_edit=False,
+        owners_can_delete=True,
+        actor="alice",
+        expect_status=200,
+    ),
+    OwnerPermissionCase(
+        description="Owner can edit their own file",
+        endpoint_path="/-/update",
+        body={"update": {"search_text": "new"}},
+        owners_can_edit=True,
+        owners_can_delete=False,
+        actor="alice",
+        expect_status=200,
+    ),
+    OwnerPermissionCase(
+        description="Owner cannot delete without owners_can_delete config",
+        endpoint_path="/-/delete",
+        body={},
+        owners_can_edit=False,
+        owners_can_delete=False,
+        actor="alice",
+        expect_status=403,
+    ),
+    OwnerPermissionCase(
+        description="Owner cannot edit without owners_can_edit config",
+        endpoint_path="/-/update",
+        body={"update": {"search_text": "new"}},
+        owners_can_edit=False,
+        owners_can_delete=False,
+        actor="alice",
+        expect_status=403,
+    ),
+    OwnerPermissionCase(
+        description="owners_can_edit does not grant delete",
+        endpoint_path="/-/delete",
+        body={},
+        owners_can_edit=True,
+        owners_can_delete=False,
+        actor="alice",
+        expect_status=403,
+    ),
+    OwnerPermissionCase(
+        description="owners_can_delete does not grant edit",
+        endpoint_path="/-/update",
+        body={"update": {"search_text": "new"}},
+        owners_can_edit=False,
+        owners_can_delete=True,
+        actor="alice",
+        expect_status=403,
+    ),
+    OwnerPermissionCase(
+        description="Non-owner cannot delete even with owners_can_delete",
+        endpoint_path="/-/delete",
+        body={},
+        owners_can_edit=False,
+        owners_can_delete=True,
+        actor="bob",
+        expect_status=403,
+    ),
+    OwnerPermissionCase(
+        description="Non-owner cannot edit even with owners_can_edit",
+        endpoint_path="/-/update",
+        body={"update": {"search_text": "new"}},
+        owners_can_edit=True,
+        owners_can_delete=False,
+        actor="bob",
+        expect_status=403,
+    ),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    OwnerPermissionCase._fields,
+    OWNER_PERMISSION_CASES,
+    ids=[c.description for c in OWNER_PERMISSION_CASES],
+)
+async def test_owner_permission(
+    upload_dir,
+    description,
+    endpoint_path,
+    body,
+    owners_can_edit,
+    owners_can_delete,
+    actor,
+    expect_status,
+):
+    ds = _make_owner_datasette(
+        upload_dir,
+        owners_can_edit=owners_can_edit,
+        owners_can_delete=owners_can_delete,
+    )
+    # Always upload as alice — actor param controls who attempts the action
+    file_id = await _upload_as(ds, "alice")
+
+    cookies = {"ds_actor": ds.sign({"a": {"id": actor}}, "actor")}
+    response = await ds.client.post(
+        f"/-/files/{file_id}{endpoint_path}",
+        content=json.dumps(body),
+        headers={"Content-Type": "application/json"},
+        cookies=cookies,
+    )
+    assert response.status_code == expect_status
+
+
+@pytest.mark.asyncio
+async def test_anonymous_upload_no_owner(upload_dir):
+    """Files uploaded without an actor have no owner — owner permissions don't apply."""
+    ds = _make_owner_datasette(upload_dir, owners_can_delete=True)
+
+    # Upload without actor
+    data = await _upload_file(ds)
+    file_id = data["file_id"]
+
+    # Even with owners_can_delete, alice can't delete an ownerless file
+    cookies = {"ds_actor": ds.sign({"a": {"id": "alice"}}, "actor")}
+    response = await ds.client.post(
+        f"/-/files/{file_id}/-/delete",
+        content=json.dumps({}),
+        headers={"Content-Type": "application/json"},
+        cookies=cookies,
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
Option to set it so the user who uploaded a file (the "owner" of that file) is granted the ability to edit metadata or delete that file, even if the other permission checks do not grant that.