### PR TITLE
`datasette-file-picker` as a web component

### DIFF
--- a/datasette_files/static/datasette-file-picker.js
+++ b/datasette_files/static/datasette-file-picker.js
@@ -1,176 +1,6 @@
-// datasette-file-picker.js
-// Opens a <dialog> for searching and uploading files, returns selected file ID.
-
-let _stylesInjected = false;
-
-function _injectStyles() {
-  if (_stylesInjected) return;
-  _stylesInjected = true;
-  const style = document.createElement("style");
-  style.textContent = `
-    .dsf-picker-dialog {
-      border: 1px solid #ccc;
-      border-radius: 8px;
-      padding: 0;
-      max-width: 520px;
-      width: 90vw;
-      max-height: 80vh;
-      display: flex;
-      flex-direction: column;
-      font-family: inherit;
-    }
-    .dsf-picker-dialog::backdrop {
-      background: rgba(0,0,0,0.4);
-    }
-    .dsf-picker-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 12px 16px;
-      border-bottom: 1px solid #eee;
-    }
-    .dsf-picker-header h3 {
-      margin: 0;
-      font-size: 1em;
-    }
-    .dsf-picker-close {
-      background: none;
-      border: none;
-      font-size: 1.3em;
-      cursor: pointer;
-      color: #666;
-      padding: 0 4px;
-    }
-    .dsf-picker-body {
-      padding: 12px 16px;
-      overflow-y: auto;
-      flex: 1;
-      min-height: 200px;
-    }
-    .dsf-picker-search {
-      width: 100%;
-      padding: 6px 10px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      font-size: 0.95em;
-      box-sizing: border-box;
-    }
-    .dsf-picker-results {
-      list-style: none;
-      padding: 0;
-      margin: 8px 0 0 0;
-    }
-    .dsf-picker-results li {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 6px 8px;
-      border-radius: 4px;
-      cursor: pointer;
-    }
-    .dsf-picker-results li:hover,
-    .dsf-picker-results li:focus {
-      background: #f0f4ff;
-      outline: 2px solid #4a90d9;
-      outline-offset: -2px;
-    }
-    .dsf-picker-results li.dsf-selected {
-      background: #e0e8ff;
-    }
-    .dsf-picker-thumb {
-      width: 32px;
-      height: 32px;
-      object-fit: cover;
-      border-radius: 3px;
-      flex-shrink: 0;
-    }
-    .dsf-picker-file-info {
-      flex: 1;
-      min-width: 0;
-    }
-    .dsf-picker-filename {
-      display: block;
-      font-size: 0.95em;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .dsf-picker-meta {
-      display: block;
-      font-size: 0.8em;
-      color: #666;
-    }
-    .dsf-picker-empty {
-      color: #999;
-      font-size: 0.9em;
-      padding: 12px 0;
-      text-align: center;
-    }
-    .dsf-picker-upload-section {
-      border-top: 1px solid #eee;
-      padding: 12px 16px;
-    }
-    .dsf-picker-upload-section summary {
-      cursor: pointer;
-      font-size: 0.9em;
-      color: #333;
-      user-select: none;
-    }
-    .dsf-picker-upload-row {
-      display: flex;
-      gap: 8px;
-      align-items: center;
-      margin-top: 8px;
-    }
-    .dsf-picker-upload-row select {
-      padding: 4px 6px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      font-size: 0.9em;
-    }
-    .dsf-picker-upload-row input[type="file"] {
-      font-size: 0.9em;
-      flex: 1;
-      min-width: 0;
-    }
-    .dsf-picker-upload-btn {
-      padding: 4px 12px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #f8f8f8;
-      cursor: pointer;
-      font-size: 0.9em;
-    }
-    .dsf-picker-upload-btn:hover {
-      background: #eee;
-    }
-    .dsf-picker-remove-btn {
-      display: block;
-      margin: 8px 0 0 0;
-      padding: 6px 12px;
-      border: 1px solid #c00;
-      border-radius: 4px;
-      background: #fff;
-      color: #c00;
-      cursor: pointer;
-      font-size: 0.9em;
-    }
-    .dsf-picker-remove-btn:hover {
-      background: #fef0f0;
-    }
-    .dsf-picker-error {
-      color: #c00;
-      font-size: 0.85em;
-      margin-top: 6px;
-    }
-    .dsf-picker-uploading {
-      color: #666;
-      font-size: 0.85em;
-      margin-top: 6px;
-    }
-  `;
-  document.head.appendChild(style);
-}
+// <datasette-file-picker> web component
+// Modal dialog for searching and selecting files, with optional upload.
+// Dispatches "file-selected" event with detail.fileId.
 
 function _getCsrfToken() {
   const match = document.cookie.match(/ds_csrftoken=([^;]+)/);
@@ -188,280 +18,480 @@ function _formatSize(bytes) {
   return gb.toFixed(1) + " GB";
 }
 
+function _escapeHtml(str) {
+  const div = document.createElement("div");
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+const PICKER_STYLES = `
+  :host {
+    display: contents;
+  }
+  dialog {
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 0;
+    max-width: 520px;
+    width: 90vw;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    font-family: inherit;
+  }
+  dialog::backdrop {
+    background: rgba(0,0,0,0.4);
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid #eee;
+  }
+  .header h3 {
+    margin: 0;
+    font-size: 1em;
+  }
+  .close-btn {
+    background: none;
+    border: none;
+    font-size: 1.3em;
+    cursor: pointer;
+    color: #666;
+    padding: 0 4px;
+  }
+  .body {
+    padding: 12px 16px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 200px;
+  }
+  .search {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.95em;
+    box-sizing: border-box;
+  }
+  .results {
+    list-style: none;
+    padding: 0;
+    margin: 8px 0 0 0;
+  }
+  .results li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .results li:hover,
+  .results li:focus {
+    background: #f0f4ff;
+    outline: 2px solid #4a90d9;
+    outline-offset: -2px;
+  }
+  .results li.selected {
+    background: #e0e8ff;
+  }
+  .thumb {
+    width: 32px;
+    height: 32px;
+    object-fit: cover;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+  .file-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .filename {
+    display: block;
+    font-size: 0.95em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .meta {
+    display: block;
+    font-size: 0.8em;
+    color: #666;
+  }
+  .empty {
+    color: #999;
+    font-size: 0.9em;
+    padding: 12px 0;
+    text-align: center;
+  }
+  .upload-section {
+    border-top: 1px solid #eee;
+    padding: 12px 16px;
+  }
+  .upload-section summary {
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #333;
+    user-select: none;
+  }
+  .upload-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-top: 8px;
+  }
+  .upload-row select {
+    padding: 4px 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+  .upload-row input[type="file"] {
+    font-size: 0.9em;
+    flex: 1;
+    min-width: 0;
+  }
+  .upload-btn {
+    padding: 4px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f8f8f8;
+    cursor: pointer;
+    font-size: 0.9em;
+  }
+  .upload-btn:hover {
+    background: #eee;
+  }
+  .remove-btn {
+    display: block;
+    margin: 8px 0 0 0;
+    padding: 6px 12px;
+    border: 1px solid #c00;
+    border-radius: 4px;
+    background: #fff;
+    color: #c00;
+    cursor: pointer;
+    font-size: 0.9em;
+  }
+  .remove-btn:hover {
+    background: #fef0f0;
+  }
+  .error {
+    color: #c00;
+    font-size: 0.85em;
+    margin-top: 6px;
+  }
+  .uploading {
+    color: #666;
+    font-size: 0.85em;
+    margin-top: 6px;
+  }
+`;
+
+class DatasetteFilePicker extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._resolved = false;
+    this._resolve = null;
+    this._searchTimer = null;
+  }
+
+  connectedCallback() {
+    const column = this.getAttribute("column") || "";
+    const currentFileId = this.getAttribute("current-file-id") || "";
+
+    this.shadowRoot.innerHTML = `
+      <style>${PICKER_STYLES}</style>
+      <dialog>
+        <div class="header">
+          <h3>Select file for <em>${_escapeHtml(column)}</em></h3>
+          <button class="close-btn" title="Close">&times;</button>
+        </div>
+        <div class="body">
+          <input type="search" class="search" placeholder="Search files..." autofocus>
+          <ul class="results" role="listbox"></ul>
+        </div>
+        <div class="upload-section">
+          <details>
+            <summary>Upload a new file</summary>
+            <div class="upload-row">
+              <select class="source-select"></select>
+              <input type="file" class="file-input">
+              <button class="upload-btn">Upload</button>
+            </div>
+            <div class="upload-status"></div>
+          </details>
+        </div>
+      </dialog>
+    `;
+
+    this._dialog = this.shadowRoot.querySelector("dialog");
+    this._searchInput = this.shadowRoot.querySelector(".search");
+    this._resultsList = this.shadowRoot.querySelector(".results");
+    this._sourceSelect = this.shadowRoot.querySelector(".source-select");
+    this._fileInput = this.shadowRoot.querySelector(".file-input");
+    this._uploadBtn = this.shadowRoot.querySelector(".upload-btn");
+    this._uploadStatus = this.shadowRoot.querySelector(".upload-status");
+
+    // Add remove button if there's a current file
+    if (currentFileId) {
+      const removeBtn = document.createElement("button");
+      removeBtn.className = "remove-btn";
+      removeBtn.textContent = "Remove file";
+      removeBtn.addEventListener("click", () => this._done(""));
+      const body = this.shadowRoot.querySelector(".body");
+      body.insertBefore(removeBtn, this._resultsList);
+    }
+
+    // Close button
+    this.shadowRoot.querySelector(".close-btn").addEventListener("click", () => this._done(null));
+    this._dialog.addEventListener("cancel", () => this._done(null));
+
+    // Search with debounce
+    this._searchInput.addEventListener("input", () => {
+      clearTimeout(this._searchTimer);
+      this._searchTimer = setTimeout(() => this._doSearch(this._searchInput.value.trim()), 300);
+    });
+
+    // Arrow down from search moves focus to first result
+    this._searchInput.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        const first = this._resultsList.querySelector("li[tabindex]");
+        if (first) first.focus();
+      }
+    });
+
+    // Upload handler
+    this._uploadBtn.addEventListener("click", () => this._handleUpload());
+
+    // Show the dialog and do initial load
+    this._dialog.showModal();
+    this._doSearch("");
+    this._loadSources();
+  }
+
+  disconnectedCallback() {
+    clearTimeout(this._searchTimer);
+  }
+
+  _done(fileId) {
+    if (this._resolved) return;
+    this._resolved = true;
+    if (this._dialog.open) this._dialog.close();
+    this.dispatchEvent(new CustomEvent("file-selected", {
+      detail: { fileId },
+      bubbles: true,
+    }));
+    if (this._resolve) this._resolve(fileId);
+    this.remove();
+  }
+
+  /** Returns a Promise that resolves when a file is selected (or dialog dismissed). */
+  get result() {
+    if (!this._resultPromise) {
+      this._resultPromise = new Promise((resolve) => {
+        this._resolve = resolve;
+      });
+    }
+    return this._resultPromise;
+  }
+
+  async _doSearch(q) {
+    try {
+      const url = q
+        ? `/-/files/search.json?q=${encodeURIComponent(q)}`
+        : `/-/files/search.json`;
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`Search failed: ${resp.status}`);
+      const data = await resp.json();
+      this._renderResults(data.files);
+    } catch (err) {
+      this._resultsList.innerHTML = `<li class="empty">Search error: ${_escapeHtml(err.message)}</li>`;
+    }
+  }
+
+  _renderResults(files) {
+    const currentFileId = this.getAttribute("current-file-id") || "";
+    this._resultsList.innerHTML = "";
+    if (files.length === 0) {
+      this._resultsList.innerHTML = '<li class="empty">No files found</li>';
+      return;
+    }
+    for (const f of files) {
+      const li = document.createElement("li");
+      li.tabIndex = 0;
+      li.setAttribute("role", "option");
+      if (f.id === currentFileId) {
+        li.classList.add("selected");
+        li.setAttribute("aria-selected", "true");
+      }
+
+      {
+        const img = document.createElement("img");
+        img.className = "thumb";
+        img.src = `/-/files/${f.id}/thumbnail`;
+        img.alt = f.filename;
+        img.loading = "lazy";
+        img.onerror = () => img.remove();
+        li.appendChild(img);
+      }
+
+      const info = document.createElement("span");
+      info.className = "file-info";
+
+      const name = document.createElement("span");
+      name.className = "filename";
+      name.textContent = f.filename;
+      info.appendChild(name);
+
+      const meta = document.createElement("span");
+      meta.className = "meta";
+      const parts = [];
+      if (f.size != null) parts.push(_formatSize(f.size));
+      if (f.source_slug) parts.push(f.source_slug);
+      meta.textContent = parts.join(" \u00b7 ");
+      info.appendChild(meta);
+
+      li.appendChild(info);
+
+      li.addEventListener("click", () => this._done(f.id));
+      li.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          this._done(f.id);
+        } else if (e.key === "ArrowDown") {
+          e.preventDefault();
+          const next = li.nextElementSibling;
+          if (next && next.tabIndex === 0) next.focus();
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          const prev = li.previousElementSibling;
+          if (prev && prev.tabIndex === 0) prev.focus();
+          else this._searchInput.focus();
+        }
+      });
+      this._resultsList.appendChild(li);
+    }
+  }
+
+  async _loadSources() {
+    try {
+      const resp = await fetch("/-/files/sources.json");
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const uploadable = data.sources.filter((s) => s.capabilities.can_upload);
+      if (uploadable.length === 0) {
+        this.shadowRoot.querySelector(".upload-section").style.display = "none";
+        return;
+      }
+      this._sourceSelect.innerHTML = "";
+      for (const s of uploadable) {
+        const opt = document.createElement("option");
+        opt.value = s.slug;
+        opt.textContent = s.slug;
+        this._sourceSelect.appendChild(opt);
+      }
+      if (uploadable.length === 1) {
+        this._sourceSelect.style.display = "none";
+      }
+    } catch {
+      this.shadowRoot.querySelector(".upload-section").style.display = "none";
+    }
+  }
+
+  async _handleUpload() {
+    const file = this._fileInput.files[0];
+    if (!file) {
+      this._uploadStatus.innerHTML = '<div class="error">Please select a file</div>';
+      return;
+    }
+    const source = this._sourceSelect.value;
+    if (!source) return;
+
+    this._uploadStatus.innerHTML = '<div class="uploading">Uploading...</div>';
+    this._uploadBtn.disabled = true;
+
+    try {
+      const csrfToken = _getCsrfToken();
+
+      // Step 1: Prepare
+      const prepResp = await fetch(`/-/files/upload/${source}/-/prepare`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrftoken": csrfToken,
+        },
+        body: JSON.stringify({
+          filename: file.name,
+          content_type: file.type || "application/octet-stream",
+          size: file.size,
+        }),
+      });
+      if (!prepResp.ok) {
+        const errData = await prepResp.json().catch(() => null);
+        throw new Error(errData?.errors?.[0] || `Prepare failed (${prepResp.status})`);
+      }
+      const prepData = await prepResp.json();
+
+      // Step 2: Upload file bytes
+      const formData = new FormData();
+      for (const [key, value] of Object.entries(prepData.upload_fields || {})) {
+        formData.append(key, value);
+      }
+      formData.append("file", file);
+
+      const uploadResp = await fetch(prepData.upload_url, {
+        method: "POST",
+        headers: prepData.upload_headers || {},
+        body: formData,
+      });
+      if (!uploadResp.ok) {
+        throw new Error(`Upload failed (${uploadResp.status})`);
+      }
+
+      // Step 3: Complete
+      const completeResp = await fetch(`/-/files/upload/${source}/-/complete`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrftoken": csrfToken,
+        },
+        body: JSON.stringify({ upload_token: prepData.upload_token }),
+      });
+      if (!completeResp.ok) {
+        const errData = await completeResp.json().catch(() => null);
+        throw new Error(errData?.errors?.[0] || `Complete failed (${completeResp.status})`);
+      }
+      const completeData = await completeResp.json();
+      this._done(completeData.file.id);
+    } catch (err) {
+      this._uploadStatus.innerHTML = `<div class="error">${_escapeHtml(err.message)}</div>`;
+      this._uploadBtn.disabled = false;
+    }
+  }
+}
+
+customElements.define("datasette-file-picker", DatasetteFilePicker);
+
 /**
  * Open a file picker dialog.
+ * Backwards-compatible wrapper — creates a <datasette-file-picker> element
+ * and returns a Promise that resolves to the selected file ID.
  * @param {Object} options
  * @param {string} options.column - Column name (shown in header)
  * @param {string} [options.currentFileId] - Currently selected file ID
  * @returns {Promise<string|null>} Selected file ID, "" to remove, or null if cancelled
  */
 export function openFilePicker({ column, currentFileId }) {
-  _injectStyles();
-
-  return new Promise((resolve) => {
-    const dialog = document.createElement("dialog");
-    dialog.className = "dsf-picker-dialog";
-
-    let _resolved = false;
-    function done(fileId) {
-      if (_resolved) return;
-      _resolved = true;
-      dialog.close();
-      dialog.remove();
-      resolve(fileId);
-    }
-
-    // Build dialog HTML
-    dialog.innerHTML = `
-      <div class="dsf-picker-header">
-        <h3>Select file for <em>${_escapeHtml(column)}</em></h3>
-        <button class="dsf-picker-close" title="Close">&times;</button>
-      </div>
-      <div class="dsf-picker-body">
-        <input type="search" class="dsf-picker-search" placeholder="Search files..." autofocus>
-        <ul class="dsf-picker-results" role="listbox"></ul>
-      </div>
-      <div class="dsf-picker-upload-section">
-        <details>
-          <summary>Upload a new file</summary>
-          <div class="dsf-picker-upload-row">
-            <select class="dsf-picker-source-select"></select>
-            <input type="file" class="dsf-picker-file-input">
-            <button class="dsf-picker-upload-btn">Upload</button>
-          </div>
-          <div class="dsf-picker-upload-status"></div>
-        </details>
-      </div>
-    `;
-
-    // Add remove button if there's a current file
-    if (currentFileId) {
-      const removeBtn = document.createElement("button");
-      removeBtn.className = "dsf-picker-remove-btn";
-      removeBtn.textContent = "Remove file";
-      removeBtn.addEventListener("click", () => done(""));
-      const body = dialog.querySelector(".dsf-picker-body");
-      body.insertBefore(removeBtn, body.querySelector(".dsf-picker-results"));
-    }
-
-    const closeBtn = dialog.querySelector(".dsf-picker-close");
-    const searchInput = dialog.querySelector(".dsf-picker-search");
-    const resultsList = dialog.querySelector(".dsf-picker-results");
-    const sourceSelect = dialog.querySelector(".dsf-picker-source-select");
-    const fileInput = dialog.querySelector(".dsf-picker-file-input");
-    const uploadBtn = dialog.querySelector(".dsf-picker-upload-btn");
-    const uploadStatus = dialog.querySelector(".dsf-picker-upload-status");
-
-    closeBtn.addEventListener("click", () => done(null));
-    dialog.addEventListener("cancel", () => done(null));
-
-    // Search with debounce
-    let _searchTimer = null;
-    searchInput.addEventListener("input", () => {
-      clearTimeout(_searchTimer);
-      _searchTimer = setTimeout(() => _doSearch(searchInput.value.trim()), 300);
-    });
-
-    // Arrow down from search moves focus to first result
-    searchInput.addEventListener("keydown", (e) => {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        const first = resultsList.querySelector("li[tabindex]");
-        if (first) first.focus();
-      }
-    });
-
-    async function _doSearch(q) {
-      try {
-        const url = q
-          ? `/-/files/search.json?q=${encodeURIComponent(q)}`
-          : `/-/files/search.json`;
-        const resp = await fetch(url);
-        if (!resp.ok) throw new Error(`Search failed: ${resp.status}`);
-        const data = await resp.json();
-        _renderResults(data.files);
-      } catch (err) {
-        resultsList.innerHTML = `<li class="dsf-picker-empty">Search error: ${_escapeHtml(err.message)}</li>`;
-      }
-    }
-
-    function _renderResults(files) {
-      resultsList.innerHTML = "";
-      if (files.length === 0) {
-        resultsList.innerHTML = '<li class="dsf-picker-empty">No files found</li>';
-        return;
-      }
-      for (const f of files) {
-        const li = document.createElement("li");
-        li.tabIndex = 0;
-        li.setAttribute("role", "option");
-        if (f.id === currentFileId) {
-          li.classList.add("dsf-selected");
-          li.setAttribute("aria-selected", "true");
-        }
-
-        {
-          const img = document.createElement("img");
-          img.className = "dsf-picker-thumb";
-          img.src = `/-/files/${f.id}/thumbnail`;
-          img.alt = f.filename;
-          img.loading = "lazy";
-          img.onerror = () => img.remove();
-          li.appendChild(img);
-        }
-
-        const info = document.createElement("span");
-        info.className = "dsf-picker-file-info";
-
-        const name = document.createElement("span");
-        name.className = "dsf-picker-filename";
-        name.textContent = f.filename;
-        info.appendChild(name);
-
-        const meta = document.createElement("span");
-        meta.className = "dsf-picker-meta";
-        const parts = [];
-        if (f.size != null) parts.push(_formatSize(f.size));
-        if (f.source_slug) parts.push(f.source_slug);
-        meta.textContent = parts.join(" \u00b7 ");
-        info.appendChild(meta);
-
-        li.appendChild(info);
-
-        li.addEventListener("click", () => done(f.id));
-        li.addEventListener("keydown", (e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            done(f.id);
-          } else if (e.key === "ArrowDown") {
-            e.preventDefault();
-            const next = li.nextElementSibling;
-            if (next && next.tabIndex === 0) next.focus();
-          } else if (e.key === "ArrowUp") {
-            e.preventDefault();
-            const prev = li.previousElementSibling;
-            if (prev && prev.tabIndex === 0) prev.focus();
-            else searchInput.focus();
-          }
-        });
-        resultsList.appendChild(li);
-      }
-    }
-
-    // Load sources for upload
-    async function _loadSources() {
-      try {
-        const resp = await fetch("/-/files/sources.json");
-        if (!resp.ok) return;
-        const data = await resp.json();
-        const uploadable = data.sources.filter((s) => s.capabilities.can_upload);
-        if (uploadable.length === 0) {
-          dialog.querySelector(".dsf-picker-upload-section").style.display =
-            "none";
-          return;
-        }
-        sourceSelect.innerHTML = "";
-        for (const s of uploadable) {
-          const opt = document.createElement("option");
-          opt.value = s.slug;
-          opt.textContent = s.slug;
-          sourceSelect.appendChild(opt);
-        }
-        if (uploadable.length === 1) {
-          sourceSelect.style.display = "none";
-        }
-      } catch {
-        // Hide upload section on error
-        dialog.querySelector(".dsf-picker-upload-section").style.display =
-          "none";
-      }
-    }
-
-    // Upload handler — uses prepare/upload/complete API
-    uploadBtn.addEventListener("click", async () => {
-      const file = fileInput.files[0];
-      if (!file) {
-        uploadStatus.innerHTML =
-          '<div class="dsf-picker-error">Please select a file</div>';
-        return;
-      }
-      const source = sourceSelect.value;
-      if (!source) return;
-
-      uploadStatus.innerHTML =
-        '<div class="dsf-picker-uploading">Uploading...</div>';
-      uploadBtn.disabled = true;
-
-      try {
-        const csrfToken = _getCsrfToken();
-
-        // Step 1: Prepare
-        const prepResp = await fetch(`/-/files/upload/${source}/-/prepare`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-csrftoken": csrfToken,
-          },
-          body: JSON.stringify({
-            filename: file.name,
-            content_type: file.type || "application/octet-stream",
-            size: file.size,
-          }),
-        });
-        if (!prepResp.ok) {
-          const errData = await prepResp.json().catch(() => null);
-          throw new Error(errData?.errors?.[0] || `Prepare failed (${prepResp.status})`);
-        }
-        const prepData = await prepResp.json();
-
-        // Step 2: Upload file bytes
-        const formData = new FormData();
-        for (const [key, value] of Object.entries(prepData.upload_fields || {})) {
-          formData.append(key, value);
-        }
-        formData.append("file", file);
-
-        const uploadResp = await fetch(prepData.upload_url, {
-          method: "POST",
-          headers: prepData.upload_headers || {},
-          body: formData,
-        });
-        if (!uploadResp.ok) {
-          throw new Error(`Upload failed (${uploadResp.status})`);
-        }
-
-        // Step 3: Complete
-        const completeResp = await fetch(`/-/files/upload/${source}/-/complete`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-csrftoken": csrfToken,
-          },
-          body: JSON.stringify({ upload_token: prepData.upload_token }),
-        });
-        if (!completeResp.ok) {
-          const errData = await completeResp.json().catch(() => null);
-          throw new Error(errData?.errors?.[0] || `Complete failed (${completeResp.status})`);
-        }
-        const completeData = await completeResp.json();
-        done(completeData.file.id);
-      } catch (err) {
-        uploadStatus.innerHTML = `<div class="dsf-picker-error">${_escapeHtml(err.message)}</div>`;
-        uploadBtn.disabled = false;
-      }
-    });
-
-    document.body.appendChild(dialog);
-    dialog.showModal();
-
-    // Initial load
-    _doSearch("");
-    _loadSources();
-  });
-}
-
-function _escapeHtml(str) {
-  const div = document.createElement("div");
-  div.textContent = str;
-  return div.innerHTML;
+  const picker = document.createElement("datasette-file-picker");
+  picker.setAttribute("column", column);
+  if (currentFileId) {
+    picker.setAttribute("current-file-id", currentFileId);
+  }
+  document.body.appendChild(picker);
+  return picker.result;
 }

--- a/tests/test-file-picker.html
+++ b/tests/test-file-picker.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>datasette-file-picker tests</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 700px; margin: 2em auto; }
+    .pass { color: green; }
+    .fail { color: red; }
+    #results { white-space: pre-wrap; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <h1>datasette-file-picker tests</h1>
+  <div id="results"></div>
+
+  <script type="module">
+    // --- Mock fetch ---
+    const MOCK_FILES = [
+      { id: "df-abc", filename: "photo.jpg", size: 204800, source_slug: "uploads" },
+      { id: "df-def", filename: "report.pdf", size: 1048576, source_slug: "docs" },
+    ];
+    const MOCK_SOURCES = {
+      sources: [
+        { slug: "uploads", capabilities: { can_upload: true } },
+        { slug: "readonly", capabilities: { can_upload: false } },
+      ],
+    };
+
+    const _realFetch = window.fetch;
+    window.fetch = async (url, opts) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.includes("/-/files/search.json")) {
+        const params = new URL(urlStr, "http://localhost").searchParams;
+        const q = params.get("q") || "";
+        const files = q
+          ? MOCK_FILES.filter((f) => f.filename.toLowerCase().includes(q.toLowerCase()))
+          : MOCK_FILES;
+        return new Response(JSON.stringify({ files }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (urlStr.includes("/-/files/sources.json")) {
+        return new Response(JSON.stringify(MOCK_SOURCES), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return _realFetch(url, opts);
+    };
+
+    // --- Test harness ---
+    const results = document.getElementById("results");
+    let passed = 0;
+    let failed = 0;
+
+    function log(msg, ok) {
+      const span = document.createElement("span");
+      span.className = ok ? "pass" : "fail";
+      span.textContent = (ok ? "PASS" : "FAIL") + ": " + msg + "\n";
+      results.appendChild(span);
+      if (ok) passed++;
+      else failed++;
+    }
+
+    function assert(condition, msg) {
+      log(msg, !!condition);
+      if (!condition) throw new Error("Assertion failed: " + msg);
+    }
+
+    // Wait for a Shadow DOM query to appear
+    function waitFor(picker, selector, timeout = 2000) {
+      return new Promise((resolve, reject) => {
+        const start = Date.now();
+        function check() {
+          const el = picker.shadowRoot?.querySelector(selector);
+          if (el) return resolve(el);
+          if (Date.now() - start > timeout) return reject(new Error(`Timeout waiting for ${selector}`));
+          requestAnimationFrame(check);
+        }
+        check();
+      });
+    }
+
+    // Wait for search results to populate
+    function waitForResults(picker, timeout = 2000) {
+      return new Promise((resolve, reject) => {
+        const start = Date.now();
+        function check() {
+          const items = picker.shadowRoot?.querySelectorAll(".results li[role='option']");
+          if (items && items.length > 0) return resolve(items);
+          if (Date.now() - start > timeout) return reject(new Error("Timeout waiting for results"));
+          requestAnimationFrame(check);
+        }
+        check();
+      });
+    }
+
+    // Small delay helper
+    const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+    // --- Import the module ---
+    const { openFilePicker } = await import("../datasette_files/static/datasette-file-picker.js");
+
+    // ===== Test 1: openFilePicker returns a Promise =====
+    async function testReturnsPromise() {
+      const promise = openFilePicker({ column: "photo" });
+      assert(promise instanceof Promise, "openFilePicker() returns a Promise");
+
+      // Find the picker element and click close to resolve it
+      const picker = document.querySelector("datasette-file-picker");
+      assert(picker !== null, "picker element is in the DOM");
+      assert(picker.shadowRoot !== null, "picker has a Shadow DOM");
+
+      const closeBtn = await waitFor(picker, ".close-btn");
+      closeBtn.click();
+
+      const result = await promise;
+      assert(result === null, "closing returns null");
+      assert(document.querySelector("datasette-file-picker") === null, "picker removed from DOM after close");
+    }
+
+    // ===== Test 2: selecting a file resolves with file ID =====
+    async function testSelectFile() {
+      const promise = openFilePicker({ column: "attachment" });
+      const picker = document.querySelector("datasette-file-picker");
+
+      const items = await waitForResults(picker);
+      assert(items.length === 2, "renders 2 mock files");
+
+      // Verify file info is rendered
+      const firstFilename = items[0].querySelector(".filename");
+      assert(firstFilename.textContent === "photo.jpg", "first result shows filename");
+
+      // Click the first result
+      items[0].click();
+
+      const result = await promise;
+      assert(result === "df-abc", "selecting file resolves with file ID 'df-abc'");
+      assert(document.querySelector("datasette-file-picker") === null, "picker removed after selection");
+    }
+
+    // ===== Test 3: column attribute is displayed =====
+    async function testColumnDisplayed() {
+      const promise = openFilePicker({ column: "my_column" });
+      const picker = document.querySelector("datasette-file-picker");
+
+      const header = await waitFor(picker, ".header h3");
+      assert(header.textContent.includes("my_column"), "header shows column name");
+
+      // Clean up
+      picker.shadowRoot.querySelector(".close-btn").click();
+      await promise;
+    }
+
+    // ===== Test 4: current-file-id shows remove button and highlights current =====
+    async function testCurrentFileId() {
+      const promise = openFilePicker({ column: "photo", currentFileId: "df-abc" });
+      const picker = document.querySelector("datasette-file-picker");
+
+      assert(picker.getAttribute("current-file-id") === "df-abc", "current-file-id attribute is set");
+
+      const removeBtn = await waitFor(picker, ".remove-btn");
+      assert(removeBtn !== null, "remove button is present when currentFileId is set");
+      assert(removeBtn.textContent === "Remove file", "remove button text is correct");
+
+      // Wait for results and check highlight
+      const items = await waitForResults(picker);
+      const selected = picker.shadowRoot.querySelector(".results li.selected");
+      assert(selected !== null, "current file is highlighted");
+      assert(selected.querySelector(".filename").textContent === "photo.jpg", "highlighted file matches currentFileId");
+
+      // Click remove
+      removeBtn.click();
+      const result = await promise;
+      assert(result === "", 'remove button resolves with empty string ""');
+    }
+
+    // ===== Test 5: no remove button when currentFileId is not set =====
+    async function testNoRemoveWithoutCurrentFile() {
+      const promise = openFilePicker({ column: "doc" });
+      const picker = document.querySelector("datasette-file-picker");
+
+      await waitForResults(picker);
+      const removeBtn = picker.shadowRoot.querySelector(".remove-btn");
+      assert(removeBtn === null, "no remove button when no currentFileId");
+
+      picker.shadowRoot.querySelector(".close-btn").click();
+      await promise;
+    }
+
+    // ===== Test 6: dialog cancel (Escape) returns null =====
+    async function testDialogCancel() {
+      const promise = openFilePicker({ column: "file" });
+      const picker = document.querySelector("datasette-file-picker");
+      const dialog = await waitFor(picker, "dialog");
+
+      assert(dialog.open, "dialog is open");
+
+      // Dispatch cancel event (simulates Escape key)
+      dialog.dispatchEvent(new Event("cancel"));
+
+      const result = await promise;
+      assert(result === null, "cancel event resolves with null");
+    }
+
+    // ===== Test 7: file-selected event is dispatched =====
+    async function testFileSelectedEvent() {
+      let eventDetail = null;
+      const handler = (e) => { eventDetail = e.detail; };
+      document.body.addEventListener("file-selected", handler);
+
+      const promise = openFilePicker({ column: "img" });
+      const picker = document.querySelector("datasette-file-picker");
+      const items = await waitForResults(picker);
+      items[1].click();
+
+      await promise;
+      assert(eventDetail !== null, "file-selected event was dispatched");
+      assert(eventDetail.fileId === "df-def", "event detail contains correct fileId");
+
+      document.body.removeEventListener("file-selected", handler);
+    }
+
+    // ===== Test 8: upload section loads sources =====
+    async function testUploadSourcesLoaded() {
+      const promise = openFilePicker({ column: "file" });
+      const picker = document.querySelector("datasette-file-picker");
+
+      // Wait for sources to load
+      await delay(100);
+      const select = picker.shadowRoot.querySelector(".source-select");
+      const options = select.querySelectorAll("option");
+      assert(options.length === 1, "only uploadable sources shown (1 of 2)");
+      assert(options[0].value === "uploads", "uploadable source is 'uploads'");
+
+      // Single source hides the select
+      assert(select.style.display === "none", "source select hidden when only one source");
+
+      picker.shadowRoot.querySelector(".close-btn").click();
+      await promise;
+    }
+
+    // ===== Test 9: web component is registered =====
+    async function testCustomElementRegistered() {
+      const Ctor = customElements.get("datasette-file-picker");
+      assert(Ctor !== undefined, "datasette-file-picker custom element is registered");
+    }
+
+    // ===== Test 10: multiple sequential opens work =====
+    async function testMultipleOpens() {
+      // First open
+      const p1 = openFilePicker({ column: "a" });
+      let picker = document.querySelector("datasette-file-picker");
+      picker.shadowRoot.querySelector(".close-btn").click();
+      const r1 = await p1;
+      assert(r1 === null, "first open resolves");
+
+      // Second open
+      const p2 = openFilePicker({ column: "b" });
+      picker = document.querySelector("datasette-file-picker");
+      assert(picker !== null, "second picker is created");
+      const items = await waitForResults(picker);
+      items[0].click();
+      const r2 = await p2;
+      assert(r2 === "df-abc", "second open resolves with selected file");
+    }
+
+    // ===== Run all tests =====
+    const tests = [
+      testReturnsPromise,
+      testSelectFile,
+      testColumnDisplayed,
+      testCurrentFileId,
+      testNoRemoveWithoutCurrentFile,
+      testDialogCancel,
+      testFileSelectedEvent,
+      testUploadSourcesLoaded,
+      testCustomElementRegistered,
+      testMultipleOpens,
+    ];
+
+    for (const test of tests) {
+      try {
+        await test();
+      } catch (err) {
+        log(`${test.name} threw: ${err.message}`, false);
+      }
+    }
+
+    // Summary
+    const summary = document.createElement("div");
+    summary.style.marginTop = "1em";
+    summary.style.fontWeight = "bold";
+    summary.textContent = `${passed} passed, ${failed} failed`;
+    summary.style.color = failed > 0 ? "red" : "green";
+    results.appendChild(summary);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Was able to use `openFilePicker()` in a plugin but it was quite hacky, thought it would be nice for `<datasette-file-picker>` to exist like the others.

There aren't any tests for the frontend stuff, so Claude came up with a standalone HTML thing. I also used `<datasette-file-picker>` in a local `datasette-ca460` build and it worked.