### PR TITLE
File column type and makeColumnField() edit UI integration

### DIFF
--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import hashlib
 import io
 import json
+from pathlib import Path
 import re
 import sqlite_utils
 import string
@@ -1762,58 +1763,53 @@ def register_routes():
 def _render_file_cell(datasette, value, column, table):
     if not isinstance(value, str) or not _FILE_ID_RE.match(value):
         return None
-    col_attr = (
-        ' data-column="{}"'.format(Markup.escape(column)) if table is not None else ""
-    )
     url = datasette.urls.path(f"/-/files/{value}")
     return Markup(
-        '<datasette-file file-id="{v}"{col}>'
+        '<datasette-file file-id="{v}">'
         '<a href="{url}">{v}</a>'
-        "</datasette-file>".format(v=value, col=col_attr, url=url)
+        "</datasette-file>".format(v=value, url=url)
     )
 
 
+def _static_plugin_url(filename, cache_key_filenames=None):
+    static_dir = Path(__file__).parent / "static"
+    cache_key_filenames = cache_key_filenames or [filename]
+    cache_key = max(
+        (static_dir / cache_key_filename).stat().st_mtime_ns
+        for cache_key_filename in cache_key_filenames
+    )
+    return f"/-/static-plugins/datasette_files/{filename}?{cache_key}"
+
+
 @hookimpl
-def extra_js_urls(template, database, table, columns, view_name, request, datasette):
+async def extra_js_urls(template, database, table, columns, view_name, request, datasette):
+    urls = []
     if view_name in ("table", "row", "database"):
-        return [
+        urls.append(
             {
-                "url": "/-/static-plugins/datasette_files/datasette-file-cell.js",
+                "url": _static_plugin_url("datasette-file-cell.js"),
                 "module": True,
             }
-        ]
-    return []
-
-
-@hookimpl
-async def extra_body_script(
-    template, database, table, columns, view_name, request, datasette
-):
-    if view_name not in ("table", "row") or table is None:
-        return ""
-    from datasette.resources import TableResource
-
-    can_update = await datasette.allowed(
-        action="update-row",
-        resource=TableResource(database=database, table=table),
-        actor=request.actor,
-    )
-    column_types = await datasette.get_column_types(database, table)
-    file_columns = [
-        column_name
-        for column_name, column_type in column_types.items()
-        if column_type.name == FileColumnType.name
-    ]
-    return "window.__datasette_files = {};".format(
-        json.dumps(
-            {
-                "canUpdate": can_update,
-                "database": database,
-                "fileColumns": file_columns,
-                "table": table,
-            }
         )
-    )
+    if view_name == "table" and database and table:
+        column_types = await datasette.get_column_types(database, table)
+        if any(
+            column_type.name == FileColumnType.name
+            for column_type in column_types.values()
+        ):
+            urls.append(
+                {
+                    "url": _static_plugin_url(
+                        "datasette-file-field.js",
+                        [
+                            "datasette-file-field.js",
+                            "datasette-file-picker.js",
+                        ],
+                    ),
+                    "module": True,
+                }
+            )
+    return urls
 
 
 def _parse_csv_preview(content_bytes, max_rows=10):

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -1559,6 +1559,27 @@ async def search_files(request, datasette):
 
     if not allowed_slugs:
         files = []
+    elif q and _FILE_ID_RE.match(q):
+        placeholders = ",".join(f":_slug_{i}" for i in range(len(allowed_slugs)))
+        search_sql = """
+            SELECT f.id, f.filename, f.content_type, f.size, f.width, f.height,
+                   f.created_at, f.uploaded_by, s.slug as source_slug
+            FROM datasette_files f
+            JOIN datasette_files_sources s ON f.source_id = s.id
+            WHERE f.id = :file_id
+            AND s.slug IN ({placeholders})
+            {source_where}
+            LIMIT 1
+        """.format(
+            placeholders=placeholders,
+            source_where="AND s.slug = :source_filter" if source_filter else "",
+        )
+        params = {"file_id": q}
+        for i, slug in enumerate(allowed_slugs):
+            params[f"_slug_{i}"] = slug
+        if source_filter:
+            params["source_filter"] = source_filter
+        files = [dict(row) for row in (await db.execute(search_sql, params)).rows]
     elif q:
         # Build prefix query: append * to each term for prefix matching, OR between terms
         terms = ['"{}"*'.format(term.replace('"', '""')) for term in q.split() if term]

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -2171,16 +2171,3 @@ def register_thumbnail_generators(datasette):
     from .pillow_thumbnails import PillowThumbnailGenerator
 
     return [PillowThumbnailGenerator()]
-
-
-@hookimpl
-def skip_csrf(datasette, scope):
-    if scope["type"] != "http":
-        return False
-    path = scope["path"]
-    if path.startswith("/-/files/upload/"):
-        return True
-    # Match /-/files/{file_id}/-/delete and /-/files/{file_id}/-/update
-    if _FILE_ID_RE.match(path.split("/")[-2] if path.count("/") >= 4 else ""):
-        if path.endswith("/-/delete") or path.endswith("/-/update"):
-            return True

--- a/datasette_files/static/datasette-file-cell.js
+++ b/datasette_files/static/datasette-file-cell.js
@@ -1,8 +1,5 @@
 // <datasette-file file-id="df-xxx"> web component
 // Batch-fetches metadata for all instances on the page in a single request.
-// Adds edit buttons when the user has update-row permission.
-
-import { openFilePicker } from "./datasette-file-picker.js";
 
 const BATCH_DELAY = 50; // ms to wait for more elements before fetching
 let _pendingIds = new Set();
@@ -52,9 +49,6 @@ async function _runBatch() {
 
   // Notify all waiting elements
   document.querySelectorAll("datasette-file").forEach((el) => el._onBatchComplete());
-
-  // After first batch, enhance empty cells in file columns
-  _enhanceEmptyFileCells();
 }
 
 const _FILE_ICON_STYLES = {
@@ -119,40 +113,6 @@ function _formatSize(bytes) {
   return gb.toFixed(1) + " GB";
 }
 
-function _getCsrfToken() {
-  const match = document.cookie.match(/ds_csrftoken=([^;]+)/);
-  return match ? match[1] : "";
-}
-
-function _getPkPath(element) {
-  const tr = element.closest("tr");
-  if (!tr) return null;
-  const pkCell = tr.querySelector("td.type-pk a");
-  if (!pkCell) return null;
-  const href = pkCell.getAttribute("href");
-  if (!href) return null;
-  // href is like "/demo/projects/1" — PK is everything after /{db}/{table}/
-  const parts = href.split("/");
-  // parts: ["", "demo", "projects", "1"] — PK is everything from index 3
-  return parts.slice(3).join("/");
-}
-
-async function _writeUpdate(database, table, pkPath, column, fileId) {
-  const resp = await fetch(`/${database}/${table}/${pkPath}/-/update`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-csrftoken": _getCsrfToken(),
-    },
-    body: JSON.stringify({ update: { [column]: fileId } }),
-  });
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Update failed (${resp.status}): ${text}`);
-  }
-  return resp.json();
-}
-
 class DatasetteFile extends HTMLElement {
   connectedCallback() {
     this._fileId = this.getAttribute("file-id");
@@ -205,142 +165,7 @@ class DatasetteFile extends HTMLElement {
       this.appendChild(size);
     }
 
-    // Add edit button if we have column context and update permission
-    this._maybeAddEditButton();
-  }
-
-  _maybeAddEditButton() {
-    const ctx = window.__datasette_files;
-    if (!ctx || !ctx.canUpdate) return;
-    const column = this.getAttribute("data-column");
-    if (!column) return;
-
-    const btn = document.createElement("a");
-    btn.href = "#";
-    btn.textContent = "\u270e";
-    btn.title = "Change file";
-    btn.style.cssText = "margin-left:4px;text-decoration:none;color:#666;font-size:0.9em;";
-    btn.addEventListener("click", async (e) => {
-      e.preventDefault();
-      await this._handleEdit(column);
-    });
-    this.appendChild(btn);
-  }
-
-  async _handleEdit(column) {
-    const ctx = window.__datasette_files;
-    if (!ctx) return;
-
-    const fileId = await openFilePicker({
-      column,
-      currentFileId: this._fileId,
-    });
-    if (fileId === null || fileId === this._fileId) return;
-
-    const pkPath = _getPkPath(this);
-    if (!pkPath) {
-      console.error("datasette-file: could not determine PK path");
-      return;
-    }
-
-    // "" means remove the file reference
-    const writeValue = fileId === "" ? null : fileId;
-
-    try {
-      await _writeUpdate(ctx.database, ctx.table, pkPath, column, writeValue);
-    } catch (err) {
-      alert("Failed to update: " + err.message);
-      return;
-    }
-
-    if (fileId === "") {
-      // Removed — reload to show empty cell
-      location.reload();
-      return;
-    }
-
-    // Re-render with new file
-    this.setAttribute("file-id", fileId);
-    this._fileId = fileId;
-    delete _cache[fileId];
-    _pendingIds.add(fileId);
-    _scheduleBatch();
   }
 }
 
 customElements.define("datasette-file", DatasetteFile);
-
-// --- Empty cell enhancement ---
-
-let _emptyEnhanced = false;
-
-function _fileColumnIndices(table, fileColumns) {
-  const indices = [];
-  const headers = Array.from(table.querySelectorAll("thead th"));
-  headers.forEach((th, idx) => {
-    const column = th.dataset.column;
-    if (column && fileColumns.includes(column)) {
-      indices.push({ index: idx, column });
-    }
-  });
-  return indices;
-}
-
-function _enhanceEmptyFileCells() {
-  if (_emptyEnhanced) return;
-
-  const ctx = window.__datasette_files;
-  if (!ctx || !ctx.canUpdate) return;
-
-  const table = document.querySelector("table.rows-and-columns");
-  if (!table) return;
-
-  const fileColumns = Array.isArray(ctx.fileColumns) ? ctx.fileColumns : [];
-  const fileColumnIndices = _fileColumnIndices(table, fileColumns);
-  if (fileColumnIndices.length === 0) return;
-
-  _emptyEnhanced = true;
-
-  // For each empty cell in a file column, inject an attach button
-  table.querySelectorAll("tbody tr").forEach((row) => {
-    fileColumnIndices.forEach(({ index, column }) => {
-      const td = row.children[index];
-      if (!td) return;
-      if (td.querySelector("datasette-file")) return;
-      if (td.querySelector(".datasette-file-attach")) return;
-      if (td.textContent.trim() !== "" && td.textContent.trim() !== "\u00a0") return;
-
-      const btn = document.createElement("a");
-      btn.className = "datasette-file-attach";
-      btn.href = "#";
-      btn.textContent = "+";
-      btn.title = "Attach file";
-      btn.style.cssText = "color:#666;text-decoration:none;font-size:1.2em;";
-      btn.addEventListener("click", async (e) => {
-        e.preventDefault();
-        const fileId = await openFilePicker({ column });
-        if (!fileId) return;
-
-        const pkPath = _getPkPath(td);
-        if (!pkPath) {
-          console.error("datasette-file: could not determine PK path");
-          return;
-        }
-
-        try {
-          await _writeUpdate(ctx.database, ctx.table, pkPath, column, fileId);
-          location.reload();
-        } catch (err) {
-          alert("Failed to update: " + err.message);
-        }
-      });
-      td.appendChild(btn);
-    });
-  });
-}
-
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", _enhanceEmptyFileCells);
-} else {
-  _enhanceEmptyFileCells();
-}

--- a/datasette_files/static/datasette-file-field.js
+++ b/datasette_files/static/datasette-file-field.js
@@ -63,12 +63,6 @@ function fileUrl(fileId) {
   return "/-/files/" + encodeURIComponent(fileId);
 }
 
-function setInputValue(input, value) {
-  input.value = value || "";
-  input.dispatchEvent(new Event("input", { bubbles: true }));
-  input.dispatchEvent(new Event("change", { bubbles: true }));
-}
-
 function renderCurrentFile(current, value) {
   current.textContent = "";
   if (!value) {
@@ -99,12 +93,11 @@ function renderCurrentFile(current, value) {
   current.appendChild(raw);
 }
 
-function renderFileField(node, field) {
+function renderFileField(field) {
   ensureFieldStyles();
 
   const input = field.input;
   input.type = "hidden";
-  input.dataset.originalValueType = "null";
   input.setAttribute("aria-hidden", "true");
 
   const wrap = document.createElement("div");
@@ -119,7 +112,7 @@ function renderFileField(node, field) {
 
   const current = document.createElement("div");
   current.className = "datasette-file-field-current";
-  renderCurrentFile(current, input.value);
+  renderCurrentFile(current, field.getValue());
 
   const actions = document.createElement("div");
   actions.className = "datasette-file-field-actions";
@@ -132,8 +125,8 @@ function renderFileField(node, field) {
   let pickerOpening = false;
 
   function updateButtons() {
-    chooseButton.textContent = input.value ? "Change file" : "Choose file";
-    removeButton.hidden = !input.value;
+    chooseButton.textContent = field.getValue() ? "Change file" : "Choose file";
+    removeButton.hidden = !field.getValue();
   }
 
   function closeInlinePicker(restoreFocus) {
@@ -165,8 +158,8 @@ function renderFileField(node, field) {
       inlinePicker = document.createElement("datasette-file-picker");
       inlinePicker.setAttribute("mode", "inline");
       inlinePicker.setAttribute("column", field.context.column);
-      if (input.value) {
-        inlinePicker.setAttribute("current-file-id", input.value);
+      if (field.getValue()) {
+        inlinePicker.setAttribute("current-file-id", field.getValue());
       }
       pickerWrap.textContent = "";
       pickerWrap.hidden = false;
@@ -182,9 +175,9 @@ function renderFileField(node, field) {
     pickerWrap.hidden = true;
     chooseButton.setAttribute("aria-expanded", "false");
 
-    if (fileId !== null && fileId !== input.value) {
-      setInputValue(input, fileId);
-      renderCurrentFile(current, input.value);
+    if (fileId !== null && fileId !== field.getValue()) {
+      field.setValue(fileId || null);
+      renderCurrentFile(current, field.getValue());
       updateButtons();
     }
     chooseButton.focus();
@@ -202,16 +195,16 @@ function renderFileField(node, field) {
   removeButton.textContent = "Remove file";
   removeButton.addEventListener("click", () => {
     closeInlinePicker(false);
-    setInputValue(input, "");
-    renderCurrentFile(current, input.value);
+    field.setValue(null);
+    renderCurrentFile(current, field.getValue());
     updateButtons();
     chooseButton.focus();
   });
   actions.appendChild(removeButton);
   updateButtons();
 
-  node.appendChild(input);
-  node.appendChild(wrap);
+  field.root.appendChild(input);
+  field.root.appendChild(wrap);
   wrap.appendChild(current);
   wrap.appendChild(actions);
   wrap.appendChild(pickerWrap);
@@ -227,14 +220,14 @@ document.addEventListener("datasette_init", function (event) {
       }
       return {
         render: renderFileField,
-        focus(node) {
-          const button = node.querySelector("button:not([hidden])");
+        focus(field) {
+          const button = field.root.querySelector("button:not([hidden])");
           if (button) {
             button.focus();
           }
         },
-        destroy(node) {
-          const picker = node.querySelector("datasette-file-picker");
+        destroy(field) {
+          const picker = field.root.querySelector("datasette-file-picker");
           if (picker) {
             picker.remove();
           }

--- a/datasette_files/static/datasette-file-field.js
+++ b/datasette_files/static/datasette-file-field.js
@@ -1,0 +1,245 @@
+const FILE_ID_RE = /^df-[a-z0-9]{26}$/;
+
+function ensureFieldStyles() {
+  if (document.querySelector("style[data-datasette-file-field]")) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.setAttribute("data-datasette-file-field", "");
+  style.textContent = `
+    .datasette-file-field {
+      display: grid;
+      gap: 8px;
+    }
+    .datasette-file-field-current {
+      min-height: 2.5rem;
+      border: 1px solid var(--rule, #ccc);
+      border-radius: 5px;
+      background: var(--paper, #eef6ff);
+      padding: 8px 10px;
+    }
+    .datasette-file-field-empty,
+    .datasette-file-field-raw {
+      color: var(--muted, #666);
+      font-size: 0.9em;
+    }
+    .datasette-file-field-raw code {
+      color: var(--ink, #111);
+      overflow-wrap: anywhere;
+    }
+    .datasette-file-field-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .datasette-file-field-picker[hidden] {
+      display: none;
+    }
+    .datasette-file-field button {
+      appearance: none;
+      border: 1px solid var(--rule, #ccc);
+      border-radius: 4px;
+      background: #fff;
+      color: var(--accent, #1a56db);
+      cursor: pointer;
+      font: inherit;
+      font-size: 0.82rem;
+      line-height: 1.2;
+      padding: 7px 10px;
+    }
+    .datasette-file-field button:hover,
+    .datasette-file-field button:focus {
+      background: #f8fafc;
+    }
+    .datasette-file-field button:focus {
+      outline: 3px solid rgba(26, 86, 219, 0.12);
+      outline-offset: 1px;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function fileUrl(fileId) {
+  return "/-/files/" + encodeURIComponent(fileId);
+}
+
+function setInputValue(input, value) {
+  input.value = value || "";
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function renderCurrentFile(current, value) {
+  current.textContent = "";
+  if (!value) {
+    const empty = document.createElement("span");
+    empty.className = "datasette-file-field-empty";
+    empty.textContent = "No file selected";
+    current.appendChild(empty);
+    return;
+  }
+
+  if (FILE_ID_RE.test(value)) {
+    const file = document.createElement("datasette-file");
+    file.setAttribute("file-id", value);
+    const fallback = document.createElement("a");
+    fallback.href = fileUrl(value);
+    fallback.textContent = value;
+    file.appendChild(fallback);
+    current.appendChild(file);
+    return;
+  }
+
+  const raw = document.createElement("span");
+  raw.className = "datasette-file-field-raw";
+  raw.appendChild(document.createTextNode("Current value: "));
+  const code = document.createElement("code");
+  code.textContent = value;
+  raw.appendChild(code);
+  current.appendChild(raw);
+}
+
+function renderFileField(node, field) {
+  ensureFieldStyles();
+
+  const input = field.input;
+  input.type = "hidden";
+  input.dataset.originalValueType = "null";
+  input.setAttribute("aria-hidden", "true");
+
+  const wrap = document.createElement("div");
+  wrap.className = "datasette-file-field";
+  wrap.setAttribute("role", "group");
+  if (field.labelId) {
+    wrap.setAttribute("aria-labelledby", field.labelId);
+  }
+  if (field.descriptionId) {
+    wrap.setAttribute("aria-describedby", field.descriptionId);
+  }
+
+  const current = document.createElement("div");
+  current.className = "datasette-file-field-current";
+  renderCurrentFile(current, input.value);
+
+  const actions = document.createElement("div");
+  actions.className = "datasette-file-field-actions";
+
+  const pickerWrap = document.createElement("div");
+  pickerWrap.className = "datasette-file-field-picker";
+  pickerWrap.id = field.id + "-file-picker";
+  pickerWrap.hidden = true;
+  let inlinePicker = null;
+  let pickerOpening = false;
+
+  function updateButtons() {
+    chooseButton.textContent = input.value ? "Change file" : "Choose file";
+    removeButton.hidden = !input.value;
+  }
+
+  function closeInlinePicker(restoreFocus) {
+    if (inlinePicker) {
+      inlinePicker.remove();
+      inlinePicker = null;
+    }
+    pickerWrap.textContent = "";
+    pickerWrap.hidden = true;
+    chooseButton.setAttribute("aria-expanded", "false");
+    if (restoreFocus) {
+      chooseButton.focus();
+    }
+  }
+
+  async function openInlinePicker() {
+    if (inlinePicker) {
+      closeInlinePicker(true);
+      return;
+    }
+    if (pickerOpening) {
+      return;
+    }
+    pickerOpening = true;
+    try {
+      const pickerUrl = new URL("./datasette-file-picker.js", import.meta.url);
+      pickerUrl.search = new URL(import.meta.url).search;
+      await import(pickerUrl.href);
+      inlinePicker = document.createElement("datasette-file-picker");
+      inlinePicker.setAttribute("mode", "inline");
+      inlinePicker.setAttribute("column", field.context.column);
+      if (input.value) {
+        inlinePicker.setAttribute("current-file-id", input.value);
+      }
+      pickerWrap.textContent = "";
+      pickerWrap.hidden = false;
+      pickerWrap.appendChild(inlinePicker);
+      chooseButton.setAttribute("aria-expanded", "true");
+    } finally {
+      pickerOpening = false;
+    }
+
+    const fileId = await inlinePicker.result;
+    inlinePicker = null;
+    pickerWrap.textContent = "";
+    pickerWrap.hidden = true;
+    chooseButton.setAttribute("aria-expanded", "false");
+
+    if (fileId !== null && fileId !== input.value) {
+      setInputValue(input, fileId);
+      renderCurrentFile(current, input.value);
+      updateButtons();
+    }
+    chooseButton.focus();
+  }
+
+  const chooseButton = document.createElement("button");
+  chooseButton.type = "button";
+  chooseButton.setAttribute("aria-controls", pickerWrap.id);
+  chooseButton.setAttribute("aria-expanded", "false");
+  chooseButton.addEventListener("click", openInlinePicker);
+  actions.appendChild(chooseButton);
+
+  const removeButton = document.createElement("button");
+  removeButton.type = "button";
+  removeButton.textContent = "Remove file";
+  removeButton.addEventListener("click", () => {
+    closeInlinePicker(false);
+    setInputValue(input, "");
+    renderCurrentFile(current, input.value);
+    updateButtons();
+    chooseButton.focus();
+  });
+  actions.appendChild(removeButton);
+  updateButtons();
+
+  node.appendChild(input);
+  node.appendChild(wrap);
+  wrap.appendChild(current);
+  wrap.appendChild(actions);
+  wrap.appendChild(pickerWrap);
+}
+
+document.addEventListener("datasette_init", function (event) {
+  event.detail.registerPlugin("datasette-files", {
+    version: "0.1",
+
+    makeColumnField(context) {
+      if (!context.columnType || context.columnType.type !== "file") {
+        return null;
+      }
+      return {
+        render: renderFileField,
+        focus(node) {
+          const button = node.querySelector("button:not([hidden])");
+          if (button) {
+            button.focus();
+          }
+        },
+        destroy(node) {
+          const picker = node.querySelector("datasette-file-picker");
+          if (picker) {
+            picker.remove();
+          }
+        },
+      };
+    },
+  });
+});

--- a/datasette_files/static/datasette-file-field.js
+++ b/datasette_files/static/datasette-file-field.js
@@ -203,11 +203,13 @@ function renderFileField(field) {
   actions.appendChild(removeButton);
   updateButtons();
 
-  field.root.appendChild(input);
-  field.root.appendChild(wrap);
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(input);
+  fragment.appendChild(wrap);
   wrap.appendChild(current);
   wrap.appendChild(actions);
   wrap.appendChild(pickerWrap);
+  return fragment;
 }
 
 document.addEventListener("datasette_init", function (event) {
@@ -216,7 +218,7 @@ document.addEventListener("datasette_init", function (event) {
 
     makeColumnField(context) {
       if (!context.columnType || context.columnType.type !== "file") {
-        return null;
+        return;
       }
       return {
         render: renderFileField,

--- a/datasette_files/static/datasette-file-picker.js
+++ b/datasette_files/static/datasette-file-picker.js
@@ -2,11 +2,6 @@
 // Modal dialog for searching and selecting files, with optional upload.
 // Dispatches "file-selected" event with detail.fileId.
 
-function _getCsrfToken() {
-  const match = document.cookie.match(/ds_csrftoken=([^;]+)/);
-  return match ? match[1] : "";
-}
-
 function _formatSize(bytes) {
   if (bytes == null) return "";
   if (bytes < 1024) return bytes + " B";
@@ -580,14 +575,11 @@ class DatasetteFilePicker extends HTMLElement {
     this._uploadBtn.disabled = true;
 
     try {
-      const csrfToken = _getCsrfToken();
-
       // Step 1: Prepare
       const prepResp = await fetch(`/-/files/upload/${source}/-/prepare`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-csrftoken": csrfToken,
         },
         body: JSON.stringify({
           filename: file.name,
@@ -622,7 +614,6 @@ class DatasetteFilePicker extends HTMLElement {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-csrftoken": csrfToken,
         },
         body: JSON.stringify({ upload_token: prepData.upload_token }),
       });

--- a/datasette_files/static/datasette-file-picker.js
+++ b/datasette_files/static/datasette-file-picker.js
@@ -28,11 +28,14 @@ const PICKER_STYLES = `
   :host {
     display: contents;
   }
+  :host([mode="inline"]) {
+    display: block;
+  }
   dialog {
     --ink: #0f0f0f;
-    --paper: #f5f3ef;
+    --paper: #eef6ff;
     --muted: #6b6b6b;
-    --rule: #e2dfd8;
+    --rule: #d8e6f5;
     --accent: #1a56db;
     --card: #ffffff;
     background: var(--card);
@@ -59,6 +62,26 @@ const PICKER_STYLES = `
     background: var(--modal-backdrop-bg, rgba(0, 0, 0, 0.5));
     backdrop-filter: var(--modal-backdrop-blur, blur(4px));
     -webkit-backdrop-filter: var(--modal-backdrop-blur, blur(4px));
+  }
+  .inline-picker {
+    --ink: #0f0f0f;
+    --paper: #eef6ff;
+    --muted: #6b6b6b;
+    --rule: #d8e6f5;
+    --accent: #1a56db;
+    --card: #ffffff;
+    background: var(--card);
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    box-sizing: border-box;
+    color: var(--ink);
+    display: flex;
+    flex-direction: column;
+    font-family: system-ui, -apple-system, sans-serif;
+    max-height: min(28rem, calc(100vh - 220px));
+    min-height: 0;
+    overflow: hidden;
+    width: 100%;
   }
   .header {
     align-items: center;
@@ -270,6 +293,24 @@ const PICKER_STYLES = `
     font-size: 0.85em;
     margin-top: 6px;
   }
+  .inline-picker .header {
+    background: var(--paper);
+    padding: 10px 12px;
+  }
+  .inline-picker .header h3 {
+    font-size: 0.88rem;
+  }
+  .inline-picker .body {
+    padding: 10px 12px 12px;
+  }
+  .inline-picker .results {
+    max-height: 14rem;
+    overflow-y: auto;
+  }
+  .inline-picker .modal-footer {
+    background: #fff;
+    padding: 10px 12px;
+  }
   @media (max-width: 640px) {
     .header,
     .body {
@@ -301,12 +342,16 @@ class DatasetteFilePicker extends HTMLElement {
   connectedCallback() {
     const column = this.getAttribute("column") || "";
     const currentFileId = this.getAttribute("current-file-id") || "";
+    const inline = this.getAttribute("mode") === "inline";
+    const titleId = "datasette-file-picker-title-" + Math.random().toString(36).slice(2);
 
     this.shadowRoot.innerHTML = `
       <style>${PICKER_STYLES}</style>
-      <dialog aria-labelledby="datasette-file-picker-title">
+      ${inline
+        ? `<div class="inline-picker" role="group" aria-labelledby="${titleId}">`
+        : `<dialog aria-labelledby="${titleId}">`}
         <div class="header">
-          <h3 id="datasette-file-picker-title">Select file for <em>${_escapeHtml(column)}</em></h3>
+          <h3 id="${titleId}">Select file for <em>${_escapeHtml(column)}</em></h3>
         </div>
         <div class="body">
           <input type="search" class="search" placeholder="Search files..." autofocus>
@@ -326,7 +371,7 @@ class DatasetteFilePicker extends HTMLElement {
         <div class="modal-footer">
           <button type="button" class="btn btn-ghost close-btn">Cancel</button>
         </div>
-      </dialog>
+      ${inline ? `</div>` : `</dialog>`}
     `;
 
     this._dialog = this.shadowRoot.querySelector("dialog");
@@ -349,7 +394,16 @@ class DatasetteFilePicker extends HTMLElement {
 
     // Close button
     this.shadowRoot.querySelector(".close-btn").addEventListener("click", () => this._done(null));
-    this._dialog.addEventListener("cancel", () => this._done(null));
+    if (this._dialog) {
+      this._dialog.addEventListener("cancel", () => this._done(null));
+    }
+    this.shadowRoot.addEventListener("keydown", (e) => {
+      if (inline && e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        this._done(null);
+      }
+    });
 
     // Search with debounce
     this._searchInput.addEventListener("input", () => {
@@ -369,20 +423,27 @@ class DatasetteFilePicker extends HTMLElement {
     // Upload handler
     this._uploadBtn.addEventListener("click", () => this._handleUpload());
 
-    // Show the dialog and do initial load
-    this._dialog.showModal();
+    if (this._dialog) {
+      this._dialog.showModal();
+    } else {
+      requestAnimationFrame(() => this._searchInput.focus());
+    }
     this._doSearch("");
     this._loadSources();
   }
 
   disconnectedCallback() {
     clearTimeout(this._searchTimer);
+    if (!this._resolved && this._resolve) {
+      this._resolved = true;
+      this._resolve(null);
+    }
   }
 
   _done(fileId) {
     if (this._resolved) return;
     this._resolved = true;
-    if (this._dialog.open) this._dialog.close();
+    if (this._dialog && this._dialog.open) this._dialog.close();
     this.dispatchEvent(new CustomEvent("file-selected", {
       detail: { fileId },
       bubbles: true,
@@ -409,17 +470,19 @@ class DatasetteFilePicker extends HTMLElement {
       const resp = await fetch(url);
       if (!resp.ok) throw new Error(`Search failed: ${resp.status}`);
       const data = await resp.json();
-      this._renderResults(data.files);
+      this._renderResults(data.files, q);
     } catch (err) {
       this._resultsList.innerHTML = `<li class="empty">Search error: ${_escapeHtml(err.message)}</li>`;
     }
   }
 
-  _renderResults(files) {
+  _renderResults(files, q = "") {
     const currentFileId = this.getAttribute("current-file-id") || "";
     this._resultsList.innerHTML = "";
     if (files.length === 0) {
-      this._resultsList.innerHTML = '<li class="empty">No files found</li>';
+      if (q) {
+        this._resultsList.innerHTML = '<li class="empty">No files found</li>';
+      }
       return;
     }
     for (const f of files) {

--- a/datasette_files/static/datasette-file-picker.js
+++ b/datasette_files/static/datasette-file-picker.js
@@ -29,111 +29,164 @@ const PICKER_STYLES = `
     display: contents;
   }
   dialog {
-    border: 1px solid #ccc;
-    border-radius: 8px;
+    --ink: #0f0f0f;
+    --paper: #f5f3ef;
+    --muted: #6b6b6b;
+    --rule: #e2dfd8;
+    --accent: #1a56db;
+    --card: #ffffff;
+    background: var(--card);
+    border: none;
+    border-radius: var(--modal-border-radius, 0.75rem);
+    box-shadow: var(--modal-shadow, 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04));
+    color: var(--ink);
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: auto;
+    max-height: min(720px, calc(100vh - 32px));
+    max-width: 95vw;
+    overflow: hidden;
     padding: 0;
-    max-width: 520px;
-    width: 90vw;
-    max-height: 80vh;
+    width: min(640px, calc(100vw - 32px));
+  }
+  dialog:not([open]) {
+    display: none;
+  }
+  dialog[open] {
     display: flex;
     flex-direction: column;
-    font-family: inherit;
   }
   dialog::backdrop {
-    background: rgba(0,0,0,0.4);
+    background: var(--modal-backdrop-bg, rgba(0, 0, 0, 0.5));
+    backdrop-filter: var(--modal-backdrop-blur, blur(4px));
+    -webkit-backdrop-filter: var(--modal-backdrop-blur, blur(4px));
   }
   .header {
-    display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 12px 16px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--rule);
+    display: flex;
+    flex-shrink: 0;
+    gap: 12px;
+    align-items: center;
+    min-width: 0;
+    padding: 20px 24px 12px;
   }
   .header h3 {
+    align-items: center;
+    color: var(--ink);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 1rem;
+    font-weight: 600;
+    gap: 0.35rem;
     margin: 0;
-    font-size: 1em;
+    min-width: 0;
   }
-  .close-btn {
-    background: none;
-    border: none;
-    font-size: 1.3em;
-    cursor: pointer;
-    color: #666;
-    padding: 0 4px;
+  .header h3 em {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.92em;
+    font-style: normal;
+    font-weight: 500;
+    padding: 2px 5px;
   }
   .body {
-    padding: 12px 16px;
-    overflow-y: auto;
     flex: 1;
-    min-height: 200px;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 16px 24px 20px;
   }
   .search {
-    width: 100%;
-    padding: 6px 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 0.95em;
     box-sizing: border-box;
+    width: 100%;
+    min-width: 0;
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    padding: 8px 10px;
+    color: var(--ink);
+    background: #fff;
+    font: inherit;
+  }
+  .search:focus {
+    border-color: var(--accent);
+    outline: 3px solid rgba(26, 86, 219, 0.12);
   }
   .results {
+    display: grid;
+    gap: 4px;
     list-style: none;
+    margin: 12px 0 0;
     padding: 0;
-    margin: 8px 0 0 0;
   }
   .results li {
-    display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 6px 8px;
-    border-radius: 4px;
+    border: 1px solid transparent;
+    border-radius: 5px;
     cursor: pointer;
+    display: flex;
+    gap: 8px;
+    min-width: 0;
+    padding: 8px 10px;
   }
   .results li:hover,
   .results li:focus {
-    background: #f0f4ff;
-    outline: 2px solid #4a90d9;
-    outline-offset: -2px;
+    background: #f8fafc;
+    border-color: var(--rule);
+    outline: 3px solid rgba(26, 86, 219, 0.12);
+    outline-offset: 1px;
   }
   .results li.selected {
-    background: #e0e8ff;
+    background: var(--paper);
+    border-color: var(--rule);
   }
   .thumb {
-    width: 32px;
-    height: 32px;
-    object-fit: cover;
     border-radius: 3px;
     flex-shrink: 0;
+    height: 40px;
+    object-fit: cover;
+    width: 52px;
   }
   .file-info {
     flex: 1;
     min-width: 0;
   }
   .filename {
+    color: var(--ink);
     display: block;
-    font-size: 0.95em;
+    font-size: 0.9rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
   .meta {
+    color: var(--muted);
     display: block;
-    font-size: 0.8em;
-    color: #666;
+    font-size: 0.78rem;
   }
   .empty {
-    color: #999;
-    font-size: 0.9em;
-    padding: 12px 0;
+    color: var(--muted);
+    cursor: default;
+    font-size: 0.9rem;
+    padding: 16px 0;
     text-align: center;
   }
+  .empty:hover,
+  .empty:focus {
+    background: transparent;
+    border-color: transparent;
+    outline: none;
+  }
   .upload-section {
-    border-top: 1px solid #eee;
-    padding: 12px 16px;
+    border-top: 1px solid var(--rule);
+    margin-top: 16px;
+    padding-top: 14px;
   }
   .upload-section summary {
+    color: var(--ink);
     cursor: pointer;
-    font-size: 0.9em;
-    color: #333;
+    font-size: 0.85rem;
+    font-weight: 500;
     user-select: none;
   }
   .upload-row {
@@ -143,50 +196,96 @@ const PICKER_STYLES = `
     margin-top: 8px;
   }
   .upload-row select {
-    padding: 4px 6px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 0.9em;
+    background: #fff;
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.85rem;
+    padding: 7px 9px;
   }
   .upload-row input[type="file"] {
-    font-size: 0.9em;
     flex: 1;
+    font-size: 0.85rem;
     min-width: 0;
   }
-  .upload-btn {
-    padding: 4px 12px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background: #f8f8f8;
-    cursor: pointer;
-    font-size: 0.9em;
+  .modal-footer {
+    align-items: center;
+    background: var(--paper);
+    border-top: 1px solid var(--rule);
+    display: flex;
+    flex-shrink: 0;
+    gap: 10px;
+    justify-content: flex-end;
+    padding: 14px 20px;
   }
+  .btn,
+  .upload-btn,
+  .remove-btn {
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    padding: 9px 20px;
+    touch-action: manipulation;
+    transition: background 0.12s;
+  }
+  .btn-ghost,
+  .remove-btn {
+    background: transparent;
+    border: 1px solid var(--rule);
+    color: var(--muted);
+  }
+  .btn-ghost:hover,
+  .remove-btn:hover {
+    background: var(--rule);
+    color: var(--ink);
+  }
+  .btn-primary,
+  .upload-btn {
+    background: var(--accent);
+    color: #fff;
+  }
+  .btn-primary:hover,
   .upload-btn:hover {
-    background: #eee;
+    background: #1949b8;
   }
   .remove-btn {
     display: block;
-    margin: 8px 0 0 0;
-    padding: 6px 12px;
-    border: 1px solid #c00;
-    border-radius: 4px;
-    background: #fff;
-    color: #c00;
-    cursor: pointer;
-    font-size: 0.9em;
-  }
-  .remove-btn:hover {
-    background: #fef0f0;
+    margin: 10px 0 0;
   }
   .error {
-    color: #c00;
+    background: #fff1f1;
+    border-left: 4px solid #b91c1c;
+    border-radius: 4px;
+    color: #7f1d1d;
+    font-size: 0.85em;
+    margin-top: 6px;
+    padding: 8px 10px;
+  }
+  .uploading {
+    color: var(--muted);
     font-size: 0.85em;
     margin-top: 6px;
   }
-  .uploading {
-    color: #666;
-    font-size: 0.85em;
-    margin-top: 6px;
+  @media (max-width: 640px) {
+    .header,
+    .body {
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+    .upload-row {
+      align-items: stretch;
+      flex-direction: column;
+    }
+    .modal-footer {
+      padding: 12px 16px;
+    }
+    .btn {
+      width: 100%;
+    }
   }
 `;
 
@@ -205,25 +304,27 @@ class DatasetteFilePicker extends HTMLElement {
 
     this.shadowRoot.innerHTML = `
       <style>${PICKER_STYLES}</style>
-      <dialog>
+      <dialog aria-labelledby="datasette-file-picker-title">
         <div class="header">
-          <h3>Select file for <em>${_escapeHtml(column)}</em></h3>
-          <button class="close-btn" title="Close">&times;</button>
+          <h3 id="datasette-file-picker-title">Select file for <em>${_escapeHtml(column)}</em></h3>
         </div>
         <div class="body">
           <input type="search" class="search" placeholder="Search files..." autofocus>
           <ul class="results" role="listbox"></ul>
+          <div class="upload-section">
+            <details>
+              <summary>Upload a new file</summary>
+              <div class="upload-row">
+                <select class="source-select"></select>
+                <input type="file" class="file-input">
+                <button class="upload-btn">Upload</button>
+              </div>
+              <div class="upload-status"></div>
+            </details>
+          </div>
         </div>
-        <div class="upload-section">
-          <details>
-            <summary>Upload a new file</summary>
-            <div class="upload-row">
-              <select class="source-select"></select>
-              <input type="file" class="file-input">
-              <button class="upload-btn">Upload</button>
-            </div>
-            <div class="upload-status"></div>
-          </details>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-ghost close-btn">Cancel</button>
         </div>
       </dialog>
     `;

--- a/datasette_files/static/datasette-file-upload.js
+++ b/datasette_files/static/datasette-file-upload.js
@@ -53,11 +53,6 @@ function _formatSize(bytes) {
   return (mb / 1024).toFixed(1) + ' GB';
 }
 
-function _getCsrfToken() {
-  const match = document.cookie.match(/ds_csrftoken=([^;]+)/);
-  return match ? match[1] : '';
-}
-
 function _setXhrHeaders(xhr, headers) {
   for (const [key, value] of Object.entries(headers || {})) {
     xhr.setRequestHeader(key, value);
@@ -347,7 +342,6 @@ class DatasetteFileUpload extends HTMLElement {
 
   async _uploadAll() {
     this._uploading = true;
-    const csrfToken = _getCsrfToken();
     const pending = this._files.filter(f => f.status === 'pending');
     this._renderFileList();
 
@@ -365,7 +359,6 @@ class DatasetteFileUpload extends HTMLElement {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-csrftoken': csrfToken,
           },
           body: JSON.stringify({
             filename: entry.file.name,
@@ -420,7 +413,6 @@ class DatasetteFileUpload extends HTMLElement {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-csrftoken': csrfToken,
           },
           body: JSON.stringify({ upload_token: prepData.upload_token }),
         });

--- a/datasette_files/templates/files_import.html
+++ b/datasette_files/templates/files_import.html
@@ -8,7 +8,6 @@
 <h2>Import options</h2>
 
 <form method="post" action="{{ urls.path('/-/files/import/' ~ file.id) }}">
-    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
     <p>
         <label for="table_name">Table name:</label>
         <input type="text" name="table_name" id="table_name" value="{{ default_table_name }}" required>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "datasette>=1.0a35",
+    "datasette>=1.0a36",
     "python-ulid",
     "sqlite-utils",
     "typing_extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "datasette>=1.0a26",
+    "datasette>=1.0a35",
     "python-ulid",
     "sqlite-utils",
     "typing_extensions",

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1656,8 +1656,9 @@ async def test_import_preview_get_404_for_missing_file(upload_dir):
 
 
 @pytest.mark.asyncio
-async def test_import_post_requires_csrf_token(upload_dir):
-    """POST /-/files/import/{file_id} without a CSRF token should return 403."""
+async def test_import_post_blocks_cross_site_requests(upload_dir):
+    """Cross-site POST to /-/files/import/{file_id} is rejected by Datasette's
+    cross-origin protection; same-origin POST goes through."""
     ds = _make_datasette(
         upload_dir,
         permissions={"files-browse": True, "files-upload": True},
@@ -1670,20 +1671,21 @@ async def test_import_post_requires_csrf_token(upload_dir):
     )
     file_id = result["file_id"]
 
-    # GET the page first to obtain the CSRF cookie
-    get_response = await ds.client.get(f"/-/files/import/{file_id}")
-    assert get_response.status_code == 200
-    csrf_cookie = get_response.cookies.get("ds_csrftoken")
-    assert csrf_cookie, "Expected ds_csrftoken cookie from GET"
-
-    # POST with the cookie but without the csrftoken form field
     response = await ds.client.post(
         f"/-/files/import/{file_id}",
         data={"table_name": "data", "database_name": "data"},
-        cookies={"ds_csrftoken": csrf_cookie},
+        headers={"sec-fetch-site": "cross-site"},
         follow_redirects=False,
     )
     assert response.status_code == 403
+
+    response = await ds.client.post(
+        f"/-/files/import/{file_id}",
+        data={"table_name": "data", "database_name": "data"},
+        headers={"sec-fetch-site": "same-origin"},
+        follow_redirects=False,
+    )
+    assert response.status_code != 403
 
 
 @pytest.mark.asyncio

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -25,7 +25,7 @@ async def test_plugin_is_installed():
     datasette = Datasette(memory=True)
     response = await datasette.client.get("/-/plugins.json")
     assert response.status_code == 200
-    installed_plugins = {p["name"] for p in response.json()}
+    installed_plugins = {p["name"] for p in response.json()["plugins"]}
     assert "datasette-files" in installed_plugins
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1046,12 +1046,12 @@ async def test_files_edit_action_registered(datasette_with_files):
     assert "files-edit" in ds.actions
 
 
-# --- render_cell with data-column ---
+# --- render_cell ---
 
 
 @pytest.mark.asyncio
-async def test_render_cell_includes_data_column(datasette_browse_allowed, upload_dir):
-    """FileColumnType.render_cell includes data-column when table context is present."""
+async def test_render_cell_outputs_datasette_file(datasette_browse_allowed, upload_dir):
+    """FileColumnType.render_cell outputs the display web component."""
     ds = datasette_browse_allowed
     data = await _upload_file(ds, filename="cell.txt", content=b"cell test")
     file_id = data["file_id"]
@@ -1067,15 +1067,16 @@ async def test_render_cell_includes_data_column(datasette_browse_allowed, upload
         request=None,
     )
     assert result is not None
-    assert 'data-column="document"' in result
     assert f'file-id="{file_id}"' in result
+    assert f'<a href="/-/files/{file_id}">{file_id}</a>' in result
+    assert "data-column" not in result
 
 
 @pytest.mark.asyncio
 async def test_render_cell_no_data_column_without_table(
     datasette_browse_allowed, upload_dir
 ):
-    """FileColumnType.render_cell omits data-column when table is None."""
+    """FileColumnType.render_cell does not add editing metadata."""
     ds = datasette_browse_allowed
     data = await _upload_file(ds, filename="cell.txt", content=b"cell test")
     file_id = data["file_id"]
@@ -1113,8 +1114,10 @@ async def test_render_cell_no_match_for_non_file_id(datasette_browse_allowed):
 
 
 @pytest.mark.asyncio
-async def test_render_cell_escapes_column_name(datasette_browse_allowed, upload_dir):
-    """FileColumnType.render_cell escapes column names to prevent XSS."""
+async def test_render_cell_does_not_include_column_name(
+    datasette_browse_allowed, upload_dir
+):
+    """FileColumnType.render_cell no longer embeds column names."""
     ds = datasette_browse_allowed
     data = await _upload_file(ds, filename="cell.txt", content=b"cell test")
     file_id = data["file_id"]
@@ -1131,7 +1134,7 @@ async def test_render_cell_escapes_column_name(datasette_browse_allowed, upload_
     )
     assert result is not None
     assert "<script>" not in result
-    assert "&lt;script&gt;" in result or "&#" in result
+    assert "data-column" not in result
 
 
 @pytest.mark.asyncio
@@ -1187,52 +1190,12 @@ async def test_table_page_only_renders_file_typed_columns(tmp_path):
     assert f">{file_id}</td>" in response.text
 
 
-# --- extra_body_script ---
+# --- extra_js_urls ---
 
 
 @pytest.mark.asyncio
-async def test_extra_body_script_on_table_page(tmp_path):
-    """extra_body_script emits window.__datasette_files on table pages."""
-    upload_dir = str(tmp_path / "uploads")
-    os.makedirs(upload_dir)
-
-    ds = Datasette(
-        [str(tmp_path / "test.db")],
-        config={
-            "plugins": {
-                "datasette-files": {
-                    "sources": {
-                        "test-src": {
-                            "storage": "filesystem",
-                            "config": {"root": upload_dir},
-                        }
-                    }
-                }
-            },
-            "permissions": {
-                "files-browse": True,
-            },
-        },
-    )
-    db = ds.get_database("test")
-    await db.execute_write(
-        "CREATE TABLE IF NOT EXISTS projects (id INTEGER PRIMARY KEY, name TEXT, logo TEXT)"
-    )
-
-    # Visit the table page as anonymous user
-    response = await ds.client.get("/test/projects")
-    assert response.status_code == 200
-    assert "window.__datasette_files" in response.text
-    # Anonymous user cannot update rows by default
-    assert '"canUpdate": false' in response.text
-    assert '"database": "test"' in response.text
-    assert '"fileColumns": []' in response.text
-    assert '"table": "projects"' in response.text
-
-
-@pytest.mark.asyncio
-async def test_extra_body_script_includes_file_columns(tmp_path):
-    """extra_body_script includes typed file columns for table-page enhancement."""
+async def test_table_page_loads_file_field_for_file_columns(tmp_path):
+    """Table pages with file columns load the modal field plugin."""
     upload_dir = str(tmp_path / "uploads")
     os.makedirs(upload_dir)
 
@@ -1272,12 +1235,14 @@ async def test_extra_body_script_includes_file_columns(tmp_path):
 
     response = await ds.client.get("/test/projects")
     assert response.status_code == 200
-    assert '"fileColumns": ["logo"]' in response.text
+    assert "datasette-file-cell.js" in response.text
+    assert "datasette-file-field.js" in response.text
+    assert "window.__datasette_files" not in response.text
 
 
 @pytest.mark.asyncio
-async def test_extra_body_script_with_update_permission(tmp_path):
-    """extra_body_script sets canUpdate true when actor has update-row permission."""
+async def test_table_page_skips_file_field_without_file_columns(tmp_path):
+    """Tables without file column types do not load the modal field plugin."""
     upload_dir = str(tmp_path / "uploads")
     os.makedirs(upload_dir)
 
@@ -1296,23 +1261,71 @@ async def test_extra_body_script_with_update_permission(tmp_path):
             },
             "permissions": {
                 "files-browse": True,
-                "update-row": True,
             },
         },
     )
     db = ds.get_database("test")
     await db.execute_write(
-        "CREATE TABLE IF NOT EXISTS projects (id INTEGER PRIMARY KEY, name TEXT)"
+        "CREATE TABLE IF NOT EXISTS projects (id INTEGER PRIMARY KEY, name TEXT, logo TEXT)"
     )
 
     response = await ds.client.get("/test/projects")
     assert response.status_code == 200
-    assert '"canUpdate": true' in response.text
+    assert "datasette-file-cell.js" in response.text
+    assert "datasette-file-field.js" not in response.text
+    assert "window.__datasette_files" not in response.text
 
 
 @pytest.mark.asyncio
-async def test_extra_body_script_not_on_non_table_pages(tmp_path):
-    """extra_body_script does not emit on non-table pages like database index."""
+async def test_row_page_does_not_load_file_field(tmp_path):
+    """The modal field plugin is only needed on table pages."""
+    upload_dir = str(tmp_path / "uploads")
+    os.makedirs(upload_dir)
+
+    ds = Datasette(
+        [str(tmp_path / "test.db")],
+        config={
+            "plugins": {
+                "datasette-files": {
+                    "sources": {
+                        "test-src": {
+                            "storage": "filesystem",
+                            "config": {"root": upload_dir},
+                        }
+                    }
+                }
+            },
+            "permissions": {
+                "files-browse": True,
+            },
+            "databases": {
+                "test": {
+                    "tables": {
+                        "projects": {
+                            "column_types": {
+                                "logo": "file",
+                            }
+                        }
+                    }
+                }
+            },
+        },
+    )
+    db = ds.get_database("test")
+    await db.execute_write(
+        "CREATE TABLE IF NOT EXISTS projects (id INTEGER PRIMARY KEY, name TEXT, logo TEXT)"
+    )
+    await db.execute_write("INSERT INTO projects (id, name) VALUES (1, 'One')")
+
+    response = await ds.client.get("/test/projects/1")
+    assert response.status_code == 200
+    assert "datasette-file-cell.js" in response.text
+    assert "datasette-file-field.js" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_extra_body_script_removed_from_database_page(tmp_path):
+    """The old window.__datasette_files page global is no longer emitted."""
     upload_dir = str(tmp_path / "uploads")
     os.makedirs(upload_dir)
 
@@ -1337,6 +1350,8 @@ async def test_extra_body_script_not_on_non_table_pages(tmp_path):
     # Database page
     response = await ds.client.get("/test")
     assert response.status_code == 200
+    assert "datasette-file-cell.js" in response.text
+    assert "datasette-file-field.js" not in response.text
     assert "window.__datasette_files" not in response.text
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -509,6 +509,36 @@ async def test_search_source_filter(datasette_browse_allowed, upload_dir):
     assert len(response.json()["files"]) == 0
 
 
+@pytest.mark.asyncio
+async def test_search_json_exact_file_id(datasette_browse_allowed, upload_dir):
+    """Searching for an exact file ID finds that file."""
+    ds = datasette_browse_allowed
+    data = await _upload_file(ds, filename="image-with-boring-name.jpg", content=b"jpg")
+    file_id = data["file_id"]
+
+    response = await ds.client.get(f"/-/files/search.json?q={file_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert [file["id"] for file in data["files"]] == [file_id]
+    assert data["files"][0]["filename"] == "image-with-boring-name.jpg"
+
+
+@pytest.mark.asyncio
+async def test_search_json_exact_file_id_respects_source_filter(
+    datasette_browse_allowed, upload_dir
+):
+    """Searching for an exact file ID still respects source=."""
+    ds = datasette_browse_allowed
+    data = await _upload_file(ds, filename="source-filtered-id.jpg", content=b"jpg")
+    file_id = data["file_id"]
+
+    response = await ds.client.get(
+        f"/-/files/search.json?q={file_id}&source=nonexistent"
+    )
+    assert response.status_code == 200
+    assert response.json()["files"] == []
+
+
 # --- Homepage action ---
 
 


### PR DESCRIPTION
Registers a `file` column type using Datasette's `register_column_types()` hook and implements the `makeColumnField()` JavaScript hook (Datasette 1.0a36) so file columns get a picker UI in the insert/edit row dialogs. Also removes the obsolete CSRF token machinery superseded by Datasette's Sec-Fetch-Site protection.

Demo:

<img width="885" height="951" alt="demo" src="https://github.com/user-attachments/assets/eaa85c38-4101-4f9e-ae22-e316323700c3" />
