### PR TITLE
Add safe thumbnail resource policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,11 @@ file-type icon. The outcome is cached so repeated page views do not repeat unsaf
 or expensive work. Successful and failed entries share a policy cache key; changing
 resource settings or a generator version invalidates them automatically.
 
+Policy decisions (file too large, unsupported type, over the pixel limit) stay
+cached until the policy changes. Failures that may be transient — storage read
+errors, generator crashes, and timeouts — are retried automatically after a
+five-minute cooldown.
+
 The byte limit is checked against recorded metadata and enforced by a bounded
 storage read. The built-in filesystem backend implements a genuinely bounded
 read. Third-party storage backends should override `read_file_limited()` to get

--- a/README.md
+++ b/README.md
@@ -484,6 +484,51 @@ When `/-/files/{file_id}/thumbnail` is requested, datasette-files will:
 
 The same generation path is also attempted eagerly after uploads complete, so generators can populate the cache before the first thumbnail request.
 
+### Thumbnail resource safety
+
+Thumbnail work has limits separate from the upload size limit. The defaults are
+designed to be safe on small instances, including machines with 256 MB of RAM:
+
+```yaml
+plugins:
+  datasette-files:
+    thumbnail_max_source_bytes: 10485760       # 10 MB
+    thumbnail_max_pixels: 12000000             # 12 megapixels
+    thumbnail_concurrency: 1
+    thumbnail_timeout_seconds: 10
+    thumbnail_process_memory_limit_bytes: 134217728  # 128 MB
+    thumbnail_eager: true
+    sources:
+      my-files:
+        storage: filesystem
+        config:
+          root: /data/uploads
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `thumbnail_max_source_bytes` | 10 MB | Skip generation before reading a larger source file |
+| `thumbnail_max_pixels` | 12,000,000 | Reject raster images whose decoded width × height is larger |
+| `thumbnail_concurrency` | 1 | Maximum number of files being read and rendered concurrently |
+| `thumbnail_timeout_seconds` | 10 | Per-generator timeout, including the built-in worker |
+| `thumbnail_process_memory_limit_bytes` | 128 MB | Address-space limit for the Pillow subprocess on Linux |
+| `thumbnail_eager` | `true` | Generate after upload; set to `false` to wait for the first request |
+
+The built-in Pillow generator always runs in a separate process. On Linux that
+process also receives the configured operating-system memory limit. Other
+platforms still get process isolation, byte and pixel limits, serialization, and
+the timeout, but not the OS address-space limit.
+
+Files that exceed a limit, time out, or fail generation receive the normal SVG
+file-type icon. The outcome is cached so repeated page views do not repeat unsafe
+or expensive work. Successful and failed entries share a policy cache key; changing
+resource settings or a generator version invalidates them automatically.
+
+The byte limit is checked against recorded metadata and enforced by a bounded
+storage read. The built-in filesystem backend implements a genuinely bounded
+read. Third-party storage backends should override `read_file_limited()` to get
+the same guarantee when their metadata cannot be trusted.
+
 ### The `ThumbnailGenerator` base class
 
 Import the base class and result dataclass from `datasette_files.base`:
@@ -497,6 +542,7 @@ Implement these methods:
 ```python
 class ThumbnailGenerator(ABC):
     name: str
+    version: str = "1"
 
     async def can_generate(self, content_type: str, filename: str) -> bool:
         ...
@@ -524,6 +570,7 @@ class ThumbnailResult:
 ```
 
 - `name`: Short identifier stored alongside generated thumbnails in the cache table
+- `version`: Cache version for the generator. Increment this when output logic changes
 - `can_generate(content_type, filename)`: Return `True` if this generator can handle the file
 - `generate(file_bytes, content_type, filename, max_width, max_height)`: Return a `ThumbnailResult` or `None`
 
@@ -652,6 +699,22 @@ async def get_file_metadata(self, path: str) -> Optional[FileMetadata]:
 async def read_file(self, path: str) -> bytes:
     # Read and return the file content
     ...
+```
+
+**`read_file_limited(path, max_bytes)`** — Return content only if it fits within
+`max_bytes`, raising `FileTooLarge` otherwise. Thumbnail generation uses this
+method. The compatibility implementation checks metadata before `read_file()`,
+but backends should override it with a bounded range or streaming read so incorrect
+metadata can never cause an unbounded allocation.
+
+```python
+from datasette_files.base import FileTooLarge
+
+async def read_file_limited(self, path: str, max_bytes: int) -> bytes:
+    content = await self.read_at_most(path, max_bytes + 1)
+    if len(content) > max_bytes:
+        raise FileTooLarge()
+    return content
 ```
 
 #### Optional methods

--- a/README.md
+++ b/README.md
@@ -579,6 +579,12 @@ class ThumbnailResult:
 - `can_generate(content_type, filename)`: Return `True` if this generator can handle the file
 - `generate(file_bytes, content_type, filename, max_width, max_height)`: Return a `ThumbnailResult` or `None`
 
+`generate()` may also raise `ThumbnailGenerationError(reason)` to record why
+generation failed. Pass `skipped=True` when the failure is a policy decision
+(for example a file over one of your own limits) that should stay cached until
+the thumbnail policy changes; without it the failure is retried after the
+cooldown described above.
+
 ### Example: PDF thumbnail generator
 
 ```python

--- a/README.md
+++ b/README.md
@@ -508,16 +508,23 @@ plugins:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `thumbnail_max_source_bytes` | 10 MB | Skip generation before reading a larger source file |
-| `thumbnail_max_pixels` | 12,000,000 | Reject raster images whose decoded width × height is larger |
+| `thumbnail_max_pixels` | 12,000,000 | Built-in generator only: reject raster images whose decoded width × height is larger |
 | `thumbnail_concurrency` | 1 | Maximum number of files being read and rendered concurrently |
 | `thumbnail_timeout_seconds` | 10 | Per-generator timeout, including the built-in worker |
-| `thumbnail_process_memory_limit_bytes` | 128 MB | Address-space limit for the Pillow subprocess on Linux |
+| `thumbnail_process_memory_limit_bytes` | 128 MB | Built-in generator only: address-space limit for the Pillow subprocess on Linux |
 | `thumbnail_eager` | `true` | Generate after upload; set to `false` to wait for the first request |
 
-The built-in Pillow generator always runs in a separate process. On Linux that
-process also receives the configured operating-system memory limit. Other
-platforms still get process isolation, byte and pixel limits, serialization, and
-the timeout, but not the OS address-space limit.
+The byte limit, concurrency limit and timeout apply to every generator. The
+pixel limit, process isolation and memory limit are properties of the built-in
+Pillow generator: it always runs in a separate process, and on Linux that
+process also receives the configured operating-system memory limit (other
+platforms still get process isolation but not the address-space limit).
+
+Third-party thumbnail generators run in the Datasette process and receive the
+full file bytes; the pixel and memory settings above do not constrain them.
+Generator plugins that decode untrusted formats should implement their own
+equivalent safeguards, such as subprocess isolation and decompression-bomb
+checks.
 
 Files that exceed a limit, time out, or fail generation receive the normal SVG
 file-type icon. The outcome is cached so repeated page views do not repeat unsafe

--- a/README.md
+++ b/README.md
@@ -921,6 +921,10 @@ The built-in `FilesystemStorage` stores files on the local filesystem. It suppor
 | `root` | Yes | Absolute path to the directory where files are stored |
 | `max_file_size` | No | Maximum upload size in bytes (defaults to 100 MB) |
 
+Note: earlier releases silently ignored a configured `max_file_size` and always
+applied the 100 MB default. The option is now enforced — uploads larger than a
+configured limit are rejected.
+
 **Capabilities:**
 
 | Capability | Value |

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -86,8 +86,23 @@ class ThumbnailSettings:
     eager: bool = True
 
 
-_thumbnail_settings = ThumbnailSettings()
-_thumbnail_semaphore = asyncio.Semaphore(_DEFAULT_THUMBNAIL_CONCURRENCY)
+@dataclass
+class _ThumbnailState:
+    """Per-instance thumbnail policy and concurrency limiter."""
+
+    settings: ThumbnailSettings
+    semaphore: asyncio.Semaphore
+
+
+def _thumbnail_state(datasette) -> _ThumbnailState:
+    """Return this instance's thumbnail state, creating it on first use."""
+    state = getattr(datasette, "_datasette_files_thumbnail_state", None)
+    if state is None:
+        config = datasette.plugin_config("datasette-files") or {}
+        settings = _thumbnail_settings_from_config(config)
+        state = _ThumbnailState(settings, asyncio.Semaphore(settings.concurrency))
+        datasette._datasette_files_thumbnail_state = state
+    return state
 
 
 def _positive_number(config, key, default, converter):
@@ -133,16 +148,16 @@ def _thumbnail_settings_from_config(config):
     )
 
 
-def _thumbnail_cache_key():
+def _thumbnail_cache_key(settings):
     generators = [
         [generator.name, str(getattr(generator, "version", "1"))]
         for generator in _thumbnail_generators
     ]
     policy = {
-        "max_source_bytes": _thumbnail_settings.max_source_bytes,
-        "max_pixels": _thumbnail_settings.max_pixels,
-        "timeout_seconds": _thumbnail_settings.timeout_seconds,
-        "memory_limit_bytes": _thumbnail_settings.memory_limit_bytes,
+        "max_source_bytes": settings.max_source_bytes,
+        "max_pixels": settings.max_pixels,
+        "timeout_seconds": settings.timeout_seconds,
+        "memory_limit_bytes": settings.memory_limit_bytes,
         "generators": generators,
     }
     return hashlib.sha256(
@@ -662,7 +677,6 @@ async def _check_browse_permission(datasette, request, source_slug):
 @hookimpl
 def startup(datasette):
     async def inner():
-        global _thumbnail_semaphore, _thumbnail_settings
         db = datasette.get_internal_database()
         await db.execute_write_script(CREATE_SQL)
 
@@ -709,8 +723,10 @@ def startup(datasette):
 
         # Read source definitions from plugin config
         config = datasette.plugin_config("datasette-files") or {}
-        _thumbnail_settings = _thumbnail_settings_from_config(config)
-        _thumbnail_semaphore = asyncio.Semaphore(_thumbnail_settings.concurrency)
+        settings = _thumbnail_settings_from_config(config)
+        datasette._datasette_files_thumbnail_state = _ThumbnailState(
+            settings, asyncio.Semaphore(settings.concurrency)
+        )
         sources_config = config.get("sources") or {}
 
         for slug, source_def in sources_config.items():
@@ -771,7 +787,7 @@ def startup(datasette):
         # limits could permanently replace working thumbnails with icons.
         await db.execute_write(
             "UPDATE datasette_files_thumbnails SET cache_key = ? WHERE cache_key IS NULL",
-            [_thumbnail_cache_key()],
+            [_thumbnail_cache_key(settings)],
         )
 
     return inner
@@ -1085,7 +1101,7 @@ async def upload_complete(request, datasette):
     row = await _get_file_record(datasette, file_id)
 
     # Eager generation is optional and failure is always non-fatal to uploads.
-    if _thumbnail_settings.eager:
+    if _thumbnail_state(datasette).settings.eager:
         try:
             await _get_or_generate_thumbnail(datasette, file_id, row)
         except Exception:
@@ -1454,7 +1470,9 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
     from .base import ThumbnailResult
 
     db = datasette.get_internal_database()
-    cache_key = _thumbnail_cache_key()
+    state = _thumbnail_state(datasette)
+    settings = state.settings
+    cache_key = _thumbnail_cache_key(settings)
 
     async def cache_state():
         """Return (hit, result): (True, ThumbnailResult) for a cached thumbnail,
@@ -1527,7 +1545,7 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
         try:
             if await asyncio.wait_for(
                 generator.can_generate(content_type, filename),
-                timeout=_thumbnail_settings.timeout_seconds,
+                timeout=settings.timeout_seconds,
             ):
                 matching_generators.append(generator)
         except Exception:
@@ -1537,11 +1555,11 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
         await cache_failure("skipped", "unsupported")
         return None
 
-    if row["size"] is not None and row["size"] > _thumbnail_settings.max_source_bytes:
+    if row["size"] is not None and row["size"] > settings.max_source_bytes:
         await cache_failure("skipped", "too_large")
         return None
 
-    async with _thumbnail_semaphore:
+    async with state.semaphore:
         # A concurrent request for this file may have populated a cache while this
         # request was waiting for the single generation slot.
         hit, cached_result = await cache_state()
@@ -1550,7 +1568,7 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
 
         try:
             file_bytes = await storage.read_file_limited(
-                row["path"], _thumbnail_settings.max_source_bytes
+                row["path"], settings.max_source_bytes
             )
         except FileTooLarge:
             await cache_failure("skipped", "too_large")
@@ -1573,7 +1591,7 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
                         max_width=200,
                         max_height=200,
                     ),
-                    timeout=_thumbnail_settings.timeout_seconds,
+                    timeout=settings.timeout_seconds,
                 )
                 if result:
                     await db.execute_write(

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -21,6 +21,11 @@ from markupsafe import Markup
 from ulid import ULID
 from . import hookspecs
 from .base import (
+    DEFAULT_THUMBNAIL_CONCURRENCY,
+    DEFAULT_THUMBNAIL_MAX_PIXELS,
+    DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES,
+    DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES,
+    DEFAULT_THUMBNAIL_TIMEOUT_SECONDS,
     FileMetadata,
     FileTooLarge,
     StorageCapabilities as StorageCapabilities,
@@ -52,11 +57,6 @@ _upload_tokens: dict[str, UploadToken] = {}
 _UPLOAD_TOKEN_TTL = 3600  # 1 hour
 _DEFAULT_MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB
 _MAX_FILENAME_BYTES = 255
-_DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES = 10 * 1024 * 1024
-_DEFAULT_THUMBNAIL_MAX_PIXELS = 12_000_000
-_DEFAULT_THUMBNAIL_CONCURRENCY = 1
-_DEFAULT_THUMBNAIL_TIMEOUT_SECONDS = 10.0
-_DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES = 128 * 1024 * 1024
 # Cached "failed" thumbnail outcomes (read errors, generator crashes, timeouts)
 # are retried after this many seconds; "skipped" outcomes are policy decisions
 # and persist until the policy cache key changes.
@@ -78,11 +78,11 @@ _thumbnail_generators: list = []
 
 @dataclass
 class ThumbnailSettings:
-    max_source_bytes: int = _DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES
-    max_pixels: int = _DEFAULT_THUMBNAIL_MAX_PIXELS
-    concurrency: int = _DEFAULT_THUMBNAIL_CONCURRENCY
-    timeout_seconds: float = _DEFAULT_THUMBNAIL_TIMEOUT_SECONDS
-    memory_limit_bytes: int = _DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES
+    max_source_bytes: int = DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES
+    max_pixels: int = DEFAULT_THUMBNAIL_MAX_PIXELS
+    concurrency: int = DEFAULT_THUMBNAIL_CONCURRENCY
+    timeout_seconds: float = DEFAULT_THUMBNAIL_TIMEOUT_SECONDS
+    memory_limit_bytes: int = DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES
     eager: bool = True
 
 
@@ -143,28 +143,28 @@ def _thumbnail_settings_from_config(config):
         max_source_bytes=_positive_number(
             config,
             "thumbnail_max_source_bytes",
-            _DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES,
+            DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES,
             int,
         ),
         max_pixels=_positive_number(
-            config, "thumbnail_max_pixels", _DEFAULT_THUMBNAIL_MAX_PIXELS, int
+            config, "thumbnail_max_pixels", DEFAULT_THUMBNAIL_MAX_PIXELS, int
         ),
         concurrency=_positive_number(
             config,
             "thumbnail_concurrency",
-            _DEFAULT_THUMBNAIL_CONCURRENCY,
+            DEFAULT_THUMBNAIL_CONCURRENCY,
             int,
         ),
         timeout_seconds=_positive_number(
             config,
             "thumbnail_timeout_seconds",
-            _DEFAULT_THUMBNAIL_TIMEOUT_SECONDS,
+            DEFAULT_THUMBNAIL_TIMEOUT_SECONDS,
             float,
         ),
         memory_limit_bytes=_positive_number(
             config,
             "thumbnail_process_memory_limit_bytes",
-            _DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES,
+            DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES,
             int,
         ),
         eager=bool(eager),

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -57,6 +57,10 @@ _DEFAULT_THUMBNAIL_MAX_PIXELS = 12_000_000
 _DEFAULT_THUMBNAIL_CONCURRENCY = 1
 _DEFAULT_THUMBNAIL_TIMEOUT_SECONDS = 10.0
 _DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES = 128 * 1024 * 1024
+# Cached "failed" thumbnail outcomes (read errors, generator crashes, timeouts)
+# are retried after this many seconds; "skipped" outcomes are policy decisions
+# and persist until the policy cache key changes.
+_THUMBNAIL_FAILURE_RETRY_SECONDS = 300
 
 pm.add_hookspecs(hookspecs)
 
@@ -1469,12 +1473,18 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
 
         failure = (
             await db.execute(
-                "SELECT cache_key FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                """SELECT cache_key, status,
+                      (julianday('now') - julianday(created_at)) * 86400 AS age_seconds
+                   FROM datasette_files_thumbnail_failures WHERE file_id = ?""",
                 [file_id],
             )
         ).first()
         if failure:
-            if failure["cache_key"] == cache_key:
+            retryable = failure["status"] == "failed" and (
+                failure["age_seconds"] is None
+                or failure["age_seconds"] > _THUMBNAIL_FAILURE_RETRY_SECONDS
+            )
+            if failure["cache_key"] == cache_key and not retryable:
                 return ("failure", None)
             await db.execute_write(
                 "DELETE FROM datasette_files_thumbnail_failures WHERE file_id = ?",
@@ -1501,7 +1511,8 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
     source_slug = row["source_slug"]
 
     if source_slug not in _sources:
-        await cache_failure("failed", "source_unavailable")
+        # A missing source is a configuration state, not a property of the file:
+        # detecting it costs nothing and it may come back, so never cache it.
         return None
 
     storage = _sources[source_slug]

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -94,6 +94,29 @@ class _ThumbnailState:
     semaphore: asyncio.Semaphore
 
 
+# In-flight eager generation tasks, referenced so they are not garbage collected
+_eager_thumbnail_tasks: set = set()
+
+
+def _schedule_eager_thumbnail(datasette, file_id, row):
+    """Generate a thumbnail in the background, without delaying the caller."""
+    task = asyncio.create_task(_get_or_generate_thumbnail(datasette, file_id, row))
+    _eager_thumbnail_tasks.add(task)
+
+    def _done(task):
+        _eager_thumbnail_tasks.discard(task)
+        if not task.cancelled():
+            task.exception()  # Thumbnail failures are never fatal to uploads
+
+    task.add_done_callback(_done)
+
+
+async def _drain_eager_thumbnails():
+    """Wait for all in-flight eager generation to finish (used by tests)."""
+    while _eager_thumbnail_tasks:
+        await asyncio.wait(list(_eager_thumbnail_tasks))
+
+
 def _thumbnail_state(datasette) -> _ThumbnailState:
     """Return this instance's thumbnail state, creating it on first use."""
     state = getattr(datasette, "_datasette_files_thumbnail_state", None)
@@ -1100,12 +1123,10 @@ async def upload_complete(request, datasette):
     # Fetch the created record for the response
     row = await _get_file_record(datasette, file_id)
 
-    # Eager generation is optional and failure is always non-fatal to uploads.
+    # Eager generation happens in the background: the upload response must not
+    # queue behind the shared generation slot.
     if _thumbnail_state(datasette).settings.eager:
-        try:
-            await _get_or_generate_thumbnail(datasette, file_id, row)
-        except Exception:
-            pass  # Thumbnail generation remains lazy/retryable where appropriate
+        _schedule_eager_thumbnail(datasette, file_id, row)
 
     return Response.json(
         {

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -1552,6 +1552,7 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
             return None
 
         last_reason = "generation_failed"
+        last_skipped = False
         last_generator = None
         for generator in matching_generators:
             last_generator = generator.name
@@ -1588,13 +1589,17 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
                     return result
             except asyncio.TimeoutError:
                 last_reason = "timeout"
+                last_skipped = False
             except ThumbnailGenerationError as ex:
                 last_reason = ex.reason
+                last_skipped = ex.skipped
             except Exception:
                 last_reason = "generation_failed"
+                last_skipped = False
 
-        status = "skipped" if last_reason in {"too_many_pixels"} else "failed"
-        await cache_failure(status, last_reason, last_generator)
+        await cache_failure(
+            "skipped" if last_skipped else "failed", last_reason, last_generator
+        )
 
     return None
 

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -697,27 +697,22 @@ async def _check_browse_permission(datasette, request, source_slug):
 # --- Startup ---
 
 
+async def _ensure_column(db, table, column, definition):
+    """Add a column to an existing table if it is missing (migration helper)."""
+    columns = (await db.execute(f"PRAGMA table_info({table})")).rows
+    if column not in {row["name"] for row in columns}:
+        await db.execute_write(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+
+
 @hookimpl
 def startup(datasette):
     async def inner():
         db = datasette.get_internal_database()
         await db.execute_write_script(CREATE_SQL)
 
-        # Migrate: add search_text column if missing (pre-existing databases)
-        columns = (await db.execute("PRAGMA table_info(datasette_files)")).rows
-        col_names = {row["name"] for row in columns}
-        if "search_text" not in col_names:
-            await db.execute_write(
-                "ALTER TABLE datasette_files ADD COLUMN search_text TEXT DEFAULT ''"
-            )
-
-        thumbnail_columns = (
-            await db.execute("PRAGMA table_info(datasette_files_thumbnails)")
-        ).rows
-        if "cache_key" not in {row["name"] for row in thumbnail_columns}:
-            await db.execute_write(
-                "ALTER TABLE datasette_files_thumbnails ADD COLUMN cache_key TEXT"
-            )
+        # Migrate pre-existing databases
+        await _ensure_column(db, "datasette_files", "search_text", "TEXT DEFAULT ''")
+        await _ensure_column(db, "datasette_files_thumbnails", "cache_key", "TEXT")
 
         # Drop and recreate FTS table + triggers to ensure schema matches
         # (safe because FTS is a secondary index rebuilt from content table)

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -187,6 +187,7 @@ def _thumbnail_cache_key(settings):
         json.dumps(policy, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
 
+
 # --- SVG file-type icon generation ---
 
 _FILE_ICON_STYLES = {
@@ -2029,7 +2030,9 @@ def _static_plugin_url(filename, cache_key_filenames=None):
 
 
 @hookimpl
-async def extra_js_urls(template, database, table, columns, view_name, request, datasette):
+async def extra_js_urls(
+    template, database, table, columns, view_name, request, datasette
+):
     urls = []
     if view_name in ("table", "row", "database"):
         urls.append(

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -1449,48 +1449,47 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
     cache_key = _thumbnail_cache_key()
 
     async def cache_state():
-        cached = (
+        """Return (hit, result): (True, ThumbnailResult) for a cached thumbnail,
+        (True, None) for a cached failure, (False, None) on a miss."""
+        rows = (
             await db.execute(
-                """SELECT thumbnail, content_type, width, height, cache_key
-                   FROM datasette_files_thumbnails WHERE file_id = ?""",
-                [file_id],
+                """
+                SELECT 'thumbnail' AS kind, thumbnail, content_type, width, height,
+                       cache_key, NULL AS status, NULL AS age_seconds
+                FROM datasette_files_thumbnails WHERE file_id = :file_id
+                UNION ALL
+                SELECT 'failure', NULL, NULL, NULL, NULL, cache_key, status,
+                       (julianday('now') - julianday(created_at)) * 86400
+                FROM datasette_files_thumbnail_failures WHERE file_id = :file_id
+                """,
+                {"file_id": file_id},
             )
-        ).first()
-        if cached:
-            if cached["cache_key"] == cache_key:
-                return (
-                    "thumbnail",
-                    ThumbnailResult(
+        ).rows
+        for cached in rows:
+            if cached["kind"] == "thumbnail":
+                if cached["cache_key"] == cache_key:
+                    return True, ThumbnailResult(
                         thumb_bytes=cached["thumbnail"],
                         content_type=cached["content_type"],
                         width=cached["width"],
                         height=cached["height"],
-                    ),
+                    )
+                await db.execute_write(
+                    "DELETE FROM datasette_files_thumbnails WHERE file_id = ?",
+                    [file_id],
                 )
-            await db.execute_write(
-                "DELETE FROM datasette_files_thumbnails WHERE file_id = ?", [file_id]
-            )
-
-        failure = (
-            await db.execute(
-                """SELECT cache_key, status,
-                      (julianday('now') - julianday(created_at)) * 86400 AS age_seconds
-                   FROM datasette_files_thumbnail_failures WHERE file_id = ?""",
-                [file_id],
-            )
-        ).first()
-        if failure:
-            retryable = failure["status"] == "failed" and (
-                failure["age_seconds"] is None
-                or failure["age_seconds"] > _THUMBNAIL_FAILURE_RETRY_SECONDS
-            )
-            if failure["cache_key"] == cache_key and not retryable:
-                return ("failure", None)
-            await db.execute_write(
-                "DELETE FROM datasette_files_thumbnail_failures WHERE file_id = ?",
-                [file_id],
-            )
-        return ("miss", None)
+            else:
+                retryable = cached["status"] == "failed" and (
+                    cached["age_seconds"] is None
+                    or cached["age_seconds"] > _THUMBNAIL_FAILURE_RETRY_SECONDS
+                )
+                if cached["cache_key"] == cache_key and not retryable:
+                    return True, None
+                await db.execute_write(
+                    "DELETE FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                    [file_id],
+                )
+        return False, None
 
     async def cache_failure(status, reason, generator=None):
         await db.execute_write(
@@ -1500,11 +1499,9 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
             [file_id, status, reason, generator, cache_key],
         )
 
-    state, cached_result = await cache_state()
-    if state == "thumbnail":
+    hit, cached_result = await cache_state()
+    if hit:
         return cached_result
-    if state == "failure":
-        return None
 
     content_type = row["content_type"] or ""
     filename = row["filename"]
@@ -1539,11 +1536,9 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
     async with _thumbnail_semaphore:
         # A concurrent request for this file may have populated a cache while this
         # request was waiting for the single generation slot.
-        state, cached_result = await cache_state()
-        if state == "thumbnail":
+        hit, cached_result = await cache_state()
+        if hit:
             return cached_result
-        if state == "failure":
-            return None
 
         try:
             file_bytes = await storage.read_file_limited(

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -766,6 +766,14 @@ def startup(datasette):
                 for gen in result:
                     _thumbnail_generators.append(gen)
 
+        # Adopt thumbnails from databases created before cache keys existed.
+        # They were valid when generated; regenerating them under the current
+        # limits could permanently replace working thumbnails with icons.
+        await db.execute_write(
+            "UPDATE datasette_files_thumbnails SET cache_key = ? WHERE cache_key IS NULL",
+            [_thumbnail_cache_key()],
+        )
+
     return inner
 
 

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -1521,7 +1521,7 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
         await cache_failure("skipped", "unsupported")
         return None
 
-    if row["size"] is None or row["size"] > _thumbnail_settings.max_source_bytes:
+    if row["size"] is not None and row["size"] > _thumbnail_settings.max_source_bytes:
         await cache_failure("skipped", "too_large")
         return None
 

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -2407,6 +2407,5 @@ def register_thumbnail_generators(datasette):
         PillowThumbnailGenerator(
             max_pixels=settings.max_pixels,
             memory_limit_bytes=settings.memory_limit_bytes,
-            timeout_seconds=settings.timeout_seconds,
         )
     ]

--- a/datasette_files/__init__.py
+++ b/datasette_files/__init__.py
@@ -20,7 +20,12 @@ from datasette.utils import await_me_maybe
 from markupsafe import Markup
 from ulid import ULID
 from . import hookspecs
-from .base import FileMetadata, StorageCapabilities as StorageCapabilities
+from .base import (
+    FileMetadata,
+    FileTooLarge,
+    StorageCapabilities as StorageCapabilities,
+    ThumbnailGenerationError,
+)
 from .filesystem import FilesystemStorage
 
 _FILE_ID_RE = re.compile(r"^df-[a-z0-9]{26}$")
@@ -47,6 +52,11 @@ _upload_tokens: dict[str, UploadToken] = {}
 _UPLOAD_TOKEN_TTL = 3600  # 1 hour
 _DEFAULT_MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB
 _MAX_FILENAME_BYTES = 255
+_DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES = 10 * 1024 * 1024
+_DEFAULT_THUMBNAIL_MAX_PIXELS = 12_000_000
+_DEFAULT_THUMBNAIL_CONCURRENCY = 1
+_DEFAULT_THUMBNAIL_TIMEOUT_SECONDS = 10.0
+_DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES = 128 * 1024 * 1024
 
 pm.add_hookspecs(hookspecs)
 
@@ -60,6 +70,80 @@ _source_meta = {}
 
 # Registry of thumbnail generators (populated in startup)
 _thumbnail_generators: list = []
+
+
+@dataclass
+class ThumbnailSettings:
+    max_source_bytes: int = _DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES
+    max_pixels: int = _DEFAULT_THUMBNAIL_MAX_PIXELS
+    concurrency: int = _DEFAULT_THUMBNAIL_CONCURRENCY
+    timeout_seconds: float = _DEFAULT_THUMBNAIL_TIMEOUT_SECONDS
+    memory_limit_bytes: int = _DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES
+    eager: bool = True
+
+
+_thumbnail_settings = ThumbnailSettings()
+_thumbnail_semaphore = asyncio.Semaphore(_DEFAULT_THUMBNAIL_CONCURRENCY)
+
+
+def _positive_number(config, key, default, converter):
+    value = converter(config.get(key, default))
+    if value <= 0:
+        raise ValueError(f"{key} must be greater than zero")
+    return value
+
+
+def _thumbnail_settings_from_config(config):
+    eager = config.get("thumbnail_eager", True)
+    if isinstance(eager, str):
+        eager = eager.lower() not in {"0", "false", "no", "off"}
+    return ThumbnailSettings(
+        max_source_bytes=_positive_number(
+            config,
+            "thumbnail_max_source_bytes",
+            _DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES,
+            int,
+        ),
+        max_pixels=_positive_number(
+            config, "thumbnail_max_pixels", _DEFAULT_THUMBNAIL_MAX_PIXELS, int
+        ),
+        concurrency=_positive_number(
+            config,
+            "thumbnail_concurrency",
+            _DEFAULT_THUMBNAIL_CONCURRENCY,
+            int,
+        ),
+        timeout_seconds=_positive_number(
+            config,
+            "thumbnail_timeout_seconds",
+            _DEFAULT_THUMBNAIL_TIMEOUT_SECONDS,
+            float,
+        ),
+        memory_limit_bytes=_positive_number(
+            config,
+            "thumbnail_process_memory_limit_bytes",
+            _DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES,
+            int,
+        ),
+        eager=bool(eager),
+    )
+
+
+def _thumbnail_cache_key():
+    generators = [
+        [generator.name, str(getattr(generator, "version", "1"))]
+        for generator in _thumbnail_generators
+    ]
+    policy = {
+        "max_source_bytes": _thumbnail_settings.max_source_bytes,
+        "max_pixels": _thumbnail_settings.max_pixels,
+        "timeout_seconds": _thumbnail_settings.timeout_seconds,
+        "memory_limit_bytes": _thumbnail_settings.memory_limit_bytes,
+        "generators": generators,
+    }
+    return hashlib.sha256(
+        json.dumps(policy, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
 
 # --- SVG file-type icon generation ---
 
@@ -285,6 +369,16 @@ CREATE TABLE IF NOT EXISTS datasette_files_thumbnails (
     width INTEGER,
     height INTEGER,
     generator TEXT,
+    cache_key TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS datasette_files_thumbnail_failures (
+    file_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    generator TEXT,
+    cache_key TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 """
@@ -564,6 +658,7 @@ async def _check_browse_permission(datasette, request, source_slug):
 @hookimpl
 def startup(datasette):
     async def inner():
+        global _thumbnail_semaphore, _thumbnail_settings
         db = datasette.get_internal_database()
         await db.execute_write_script(CREATE_SQL)
 
@@ -573,6 +668,14 @@ def startup(datasette):
         if "search_text" not in col_names:
             await db.execute_write(
                 "ALTER TABLE datasette_files ADD COLUMN search_text TEXT DEFAULT ''"
+            )
+
+        thumbnail_columns = (
+            await db.execute("PRAGMA table_info(datasette_files_thumbnails)")
+        ).rows
+        if "cache_key" not in {row["name"] for row in thumbnail_columns}:
+            await db.execute_write(
+                "ALTER TABLE datasette_files_thumbnails ADD COLUMN cache_key TEXT"
             )
 
         # Drop and recreate FTS table + triggers to ensure schema matches
@@ -602,6 +705,8 @@ def startup(datasette):
 
         # Read source definitions from plugin config
         config = datasette.plugin_config("datasette-files") or {}
+        _thumbnail_settings = _thumbnail_settings_from_config(config)
+        _thumbnail_semaphore = asyncio.Semaphore(_thumbnail_settings.concurrency)
         sources_config = config.get("sources") or {}
 
         for slug, source_def in sources_config.items():
@@ -967,11 +1072,12 @@ async def upload_complete(request, datasette):
     # Fetch the created record for the response
     row = await _get_file_record(datasette, file_id)
 
-    # Eagerly generate thumbnails when a registered generator can handle the file.
-    try:
-        await _get_or_generate_thumbnail(datasette, file_id, row)
-    except Exception:
-        pass  # Non-fatal: thumbnail will be generated lazily on first request
+    # Eager generation is optional and failure is always non-fatal to uploads.
+    if _thumbnail_settings.eager:
+        try:
+            await _get_or_generate_thumbnail(datasette, file_id, row)
+        except Exception:
+            pass  # Thumbnail generation remains lazy/retryable where appropriate
 
     return Response.json(
         {
@@ -1029,6 +1135,9 @@ async def file_delete(request, datasette):
     db = datasette.get_internal_database()
     await db.execute_write(
         "DELETE FROM datasette_files_thumbnails WHERE file_id = ?", [file_id]
+    )
+    await db.execute_write(
+        "DELETE FROM datasette_files_thumbnail_failures WHERE file_id = ?", [file_id]
     )
     await db.execute_write("DELETE FROM datasette_files WHERE id = ?", [file_id])
 
@@ -1333,26 +1442,66 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
     from .base import ThumbnailResult
 
     db = datasette.get_internal_database()
+    cache_key = _thumbnail_cache_key()
 
-    cached = (
-        await db.execute(
-            "SELECT thumbnail, content_type, width, height FROM datasette_files_thumbnails WHERE file_id = ?",
-            [file_id],
+    async def cache_state():
+        cached = (
+            await db.execute(
+                """SELECT thumbnail, content_type, width, height, cache_key
+                   FROM datasette_files_thumbnails WHERE file_id = ?""",
+                [file_id],
+            )
+        ).first()
+        if cached:
+            if cached["cache_key"] == cache_key:
+                return (
+                    "thumbnail",
+                    ThumbnailResult(
+                        thumb_bytes=cached["thumbnail"],
+                        content_type=cached["content_type"],
+                        width=cached["width"],
+                        height=cached["height"],
+                    ),
+                )
+            await db.execute_write(
+                "DELETE FROM datasette_files_thumbnails WHERE file_id = ?", [file_id]
+            )
+
+        failure = (
+            await db.execute(
+                "SELECT cache_key FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                [file_id],
+            )
+        ).first()
+        if failure:
+            if failure["cache_key"] == cache_key:
+                return ("failure", None)
+            await db.execute_write(
+                "DELETE FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                [file_id],
+            )
+        return ("miss", None)
+
+    async def cache_failure(status, reason, generator=None):
+        await db.execute_write(
+            """INSERT OR REPLACE INTO datasette_files_thumbnail_failures
+               (file_id, status, reason, generator, cache_key, created_at)
+               VALUES (?, ?, ?, ?, ?, datetime('now'))""",
+            [file_id, status, reason, generator, cache_key],
         )
-    ).first()
-    if cached:
-        return ThumbnailResult(
-            thumb_bytes=cached["thumbnail"],
-            content_type=cached["content_type"],
-            width=cached["width"],
-            height=cached["height"],
-        )
+
+    state, cached_result = await cache_state()
+    if state == "thumbnail":
+        return cached_result
+    if state == "failure":
+        return None
 
     content_type = row["content_type"] or ""
     filename = row["filename"]
     source_slug = row["source_slug"]
 
     if source_slug not in _sources:
+        await cache_failure("failed", "source_unavailable")
         return None
 
     storage = _sources[source_slug]
@@ -1360,41 +1509,86 @@ async def _get_or_generate_thumbnail(datasette, file_id, row):
     matching_generators = []
     for generator in _thumbnail_generators:
         try:
-            if await generator.can_generate(content_type, filename):
+            if await asyncio.wait_for(
+                generator.can_generate(content_type, filename),
+                timeout=_thumbnail_settings.timeout_seconds,
+            ):
                 matching_generators.append(generator)
         except Exception:
             continue
 
     if not matching_generators:
+        await cache_failure("skipped", "unsupported")
         return None
 
-    try:
-        file_bytes = await storage.read_file(row["path"])
-    except Exception:
+    if row["size"] is None or row["size"] > _thumbnail_settings.max_source_bytes:
+        await cache_failure("skipped", "too_large")
         return None
 
-    for generator in matching_generators:
+    async with _thumbnail_semaphore:
+        # A concurrent request for this file may have populated a cache while this
+        # request was waiting for the single generation slot.
+        state, cached_result = await cache_state()
+        if state == "thumbnail":
+            return cached_result
+        if state == "failure":
+            return None
+
         try:
-            result = await generator.generate(
-                file_bytes, content_type, filename, max_width=200, max_height=200
+            file_bytes = await storage.read_file_limited(
+                row["path"], _thumbnail_settings.max_source_bytes
             )
-            if result:
-                await db.execute_write(
-                    """INSERT OR REPLACE INTO datasette_files_thumbnails
-                       (file_id, thumbnail, content_type, width, height, generator)
-                       VALUES (?, ?, ?, ?, ?, ?)""",
-                    [
-                        file_id,
-                        result.thumb_bytes,
-                        result.content_type,
-                        result.width,
-                        result.height,
-                        generator.name,
-                    ],
-                )
-                return result
+        except FileTooLarge:
+            await cache_failure("skipped", "too_large")
+            return None
         except Exception:
-            continue
+            await cache_failure("failed", "read_failed")
+            return None
+
+        last_reason = "generation_failed"
+        last_generator = None
+        for generator in matching_generators:
+            last_generator = generator.name
+            try:
+                result = await asyncio.wait_for(
+                    generator.generate(
+                        file_bytes,
+                        content_type,
+                        filename,
+                        max_width=200,
+                        max_height=200,
+                    ),
+                    timeout=_thumbnail_settings.timeout_seconds,
+                )
+                if result:
+                    await db.execute_write(
+                        """INSERT OR REPLACE INTO datasette_files_thumbnails
+                           (file_id, thumbnail, content_type, width, height, generator, cache_key)
+                           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                        [
+                            file_id,
+                            result.thumb_bytes,
+                            result.content_type,
+                            result.width,
+                            result.height,
+                            generator.name,
+                            cache_key,
+                        ],
+                    )
+                    await db.execute_write(
+                        "DELETE FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                        [file_id],
+                    )
+                    return result
+            except asyncio.TimeoutError:
+                last_reason = "timeout"
+            except ThumbnailGenerationError as ex:
+                last_reason = ex.reason
+            except Exception:
+                last_reason = "generation_failed"
+
+        status = "skipped" if last_reason in {"too_many_pixels"} else "failed"
+        await cache_failure(status, last_reason, last_generator)
 
     return None
 
@@ -2170,4 +2364,12 @@ async def homepage_actions(datasette, actor, request):
 def register_thumbnail_generators(datasette):
     from .pillow_thumbnails import PillowThumbnailGenerator
 
-    return [PillowThumbnailGenerator()]
+    config = datasette.plugin_config("datasette-files") if datasette else {}
+    settings = _thumbnail_settings_from_config(config or {})
+    return [
+        PillowThumbnailGenerator(
+            max_pixels=settings.max_pixels,
+            memory_limit_bytes=settings.memory_limit_bytes,
+            timeout_seconds=settings.timeout_seconds,
+        )
+    ]

--- a/datasette_files/base.py
+++ b/datasette_files/base.py
@@ -95,7 +95,7 @@ class Storage(ABC):
         metadata = await self.get_file_metadata(path)
         if metadata is None:
             raise FileNotFoundError(f"File not found: {path}")
-        if metadata.size is None or metadata.size > max_bytes:
+        if metadata.size is not None and metadata.size > max_bytes:
             raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
         content = await self.read_file(path)
         if len(content) > max_bytes:

--- a/datasette_files/base.py
+++ b/datasette_files/base.py
@@ -5,8 +5,21 @@ from dataclasses import dataclass, field
 from typing import Optional, AsyncIterator
 
 
+# Thumbnail resource-safety defaults, shared by the coordinator and the
+# built-in Pillow generator so documented and enforced limits cannot drift.
+DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES = 10 * 1024 * 1024
+DEFAULT_THUMBNAIL_MAX_PIXELS = 12_000_000
+DEFAULT_THUMBNAIL_CONCURRENCY = 1
+DEFAULT_THUMBNAIL_TIMEOUT_SECONDS = 10.0
+DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES = 128 * 1024 * 1024
+
+
 class FileTooLarge(Exception):
     """Raised when a bounded storage read exceeds its byte limit."""
+
+    @classmethod
+    def for_limit(cls, max_bytes: int) -> "FileTooLarge":
+        return cls(f"File exceeds the {max_bytes} byte read limit")
 
 
 class ThumbnailGenerationError(Exception):
@@ -102,10 +115,10 @@ class Storage(ABC):
         if metadata is None:
             raise FileNotFoundError(f"File not found: {path}")
         if metadata.size is not None and metadata.size > max_bytes:
-            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+            raise FileTooLarge.for_limit(max_bytes)
         content = await self.read_file(path)
         if len(content) > max_bytes:
-            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+            raise FileTooLarge.for_limit(max_bytes)
         return content
 
     # Optional methods — override based on capabilities

--- a/datasette_files/base.py
+++ b/datasette_files/base.py
@@ -10,11 +10,17 @@ class FileTooLarge(Exception):
 
 
 class ThumbnailGenerationError(Exception):
-    """A safe, cacheable thumbnail generation failure."""
+    """A safe, cacheable thumbnail generation failure.
 
-    def __init__(self, reason: str):
+    Set ``skipped=True`` when the failure is a policy decision (for example an
+    image over a configured limit) that should stay cached until the policy
+    changes, rather than a fault worth retrying.
+    """
+
+    def __init__(self, reason: str, *, skipped: bool = False):
         super().__init__(reason)
         self.reason = reason
+        self.skipped = skipped
 
 
 @dataclass

--- a/datasette_files/base.py
+++ b/datasette_files/base.py
@@ -172,6 +172,7 @@ class ThumbnailGenerator(ABC):
     """Abstract base for thumbnail generators."""
 
     name: str
+    version: str = "1"
 
     @abstractmethod
     async def can_generate(self, content_type: str, filename: str) -> bool:

--- a/datasette_files/base.py
+++ b/datasette_files/base.py
@@ -5,6 +5,18 @@ from dataclasses import dataclass, field
 from typing import Optional, AsyncIterator
 
 
+class FileTooLarge(Exception):
+    """Raised when a bounded storage read exceeds its byte limit."""
+
+
+class ThumbnailGenerationError(Exception):
+    """A safe, cacheable thumbnail generation failure."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
 @dataclass
 class FileMetadata:
     """Metadata about a file in a storage backend."""
@@ -71,6 +83,24 @@ class Storage(ABC):
     async def read_file(self, path: str) -> bytes:
         """Return the full content of a file. Raises FileNotFoundError if missing."""
         ...
+
+    async def read_file_limited(self, path: str, max_bytes: int) -> bytes:
+        """Return content while refusing known or actual content over max_bytes.
+
+        Backends should override this with a genuinely bounded implementation. The
+        default checks metadata before calling the legacy ``read_file()`` method,
+        then verifies the returned byte count for compatibility with existing
+        storage plugins.
+        """
+        metadata = await self.get_file_metadata(path)
+        if metadata is None:
+            raise FileNotFoundError(f"File not found: {path}")
+        if metadata.size is None or metadata.size > max_bytes:
+            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+        content = await self.read_file(path)
+        if len(content) > max_bytes:
+            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+        return content
 
     # Optional methods — override based on capabilities
 

--- a/datasette_files/base.py
+++ b/datasette_files/base.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, AsyncIterator
 
-
 # Thumbnail resource-safety defaults, shared by the coordinator and the
 # built-in Pillow generator so documented and enforced limits cannot drift.
 DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES = 10 * 1024 * 1024

--- a/datasette_files/filesystem.py
+++ b/datasette_files/filesystem.py
@@ -1,3 +1,4 @@
+import dataclasses
 import hashlib
 from pathlib import Path
 from typing import AsyncIterator, Optional
@@ -19,12 +20,8 @@ class FilesystemStorage(Storage):
 
     async def configure(self, config: dict, get_secret) -> None:
         self.root = Path(config["root"]).resolve()
-        self.capabilities = StorageCapabilities(
-            can_upload=True,
-            can_delete=True,
-            can_list=True,
-            can_generate_signed_urls=False,
-            requires_proxy_download=True,
+        self.capabilities = dataclasses.replace(
+            FilesystemStorage.capabilities,
             max_file_size=config.get("max_file_size"),
         )
         self.root.mkdir(parents=True, exist_ok=True)

--- a/datasette_files/filesystem.py
+++ b/datasette_files/filesystem.py
@@ -2,7 +2,7 @@ import hashlib
 from pathlib import Path
 from typing import AsyncIterator, Optional
 
-from .base import FileMetadata, Storage, StorageCapabilities
+from .base import FileMetadata, FileTooLarge, Storage, StorageCapabilities
 
 
 class FilesystemStorage(Storage):
@@ -19,7 +19,14 @@ class FilesystemStorage(Storage):
 
     async def configure(self, config: dict, get_secret) -> None:
         self.root = Path(config["root"]).resolve()
-        self.max_file_size = config.get("max_file_size")
+        self.capabilities = StorageCapabilities(
+            can_upload=True,
+            can_delete=True,
+            can_list=True,
+            can_generate_signed_urls=False,
+            requires_proxy_download=True,
+            max_file_size=config.get("max_file_size"),
+        )
         self.root.mkdir(parents=True, exist_ok=True)
 
     def _safe_path(self, path: str) -> Path:
@@ -44,6 +51,18 @@ class FilesystemStorage(Storage):
         if not target.exists():
             raise FileNotFoundError(f"File not found: {path}")
         return target.read_bytes()
+
+    async def read_file_limited(self, path: str, max_bytes: int) -> bytes:
+        target = self._safe_path(path)
+        if not target.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+        if target.stat().st_size > max_bytes:
+            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+        with open(target, "rb") as fileobj:
+            content = fileobj.read(max_bytes + 1)
+        if len(content) > max_bytes:
+            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+        return content
 
     async def stream_file(self, path: str) -> AsyncIterator[bytes]:
         target = self._safe_path(path)

--- a/datasette_files/filesystem.py
+++ b/datasette_files/filesystem.py
@@ -57,11 +57,11 @@ class FilesystemStorage(Storage):
         if not target.exists():
             raise FileNotFoundError(f"File not found: {path}")
         if target.stat().st_size > max_bytes:
-            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+            raise FileTooLarge.for_limit(max_bytes)
         with open(target, "rb") as fileobj:
             content = fileobj.read(max_bytes + 1)
         if len(content) > max_bytes:
-            raise FileTooLarge(f"File exceeds the {max_bytes} byte read limit")
+            raise FileTooLarge.for_limit(max_bytes)
         return content
 
     async def stream_file(self, path: str) -> AsyncIterator[bytes]:

--- a/datasette_files/pillow_thumbnails.py
+++ b/datasette_files/pillow_thumbnails.py
@@ -23,7 +23,7 @@ SUPPORTED_CONTENT_TYPES = {
 _WORKER_COMMAND = [sys.executable, "-m", "datasette_files.pillow_worker"]
 
 
-def _parse_worker_response(stdout: bytes, returncode) -> tuple[ThumbnailResult, int]:
+def _parse_worker_response(stdout: bytes, returncode) -> ThumbnailResult:
     header, separator, thumbnail = stdout.partition(b"\n")
     if returncode or not separator:
         raise ThumbnailGenerationError("generation_failed")
@@ -36,14 +36,11 @@ def _parse_worker_response(stdout: bytes, returncode) -> tuple[ThumbnailResult, 
             response.get("reason", "generation_failed"),
             skipped=bool(response.get("skipped")),
         )
-    return (
-        ThumbnailResult(
-            thumb_bytes=thumbnail,
-            content_type=response["content_type"],
-            width=response["width"],
-            height=response["height"],
-        ),
-        response["pid"],
+    return ThumbnailResult(
+        thumb_bytes=thumbnail,
+        content_type=response["content_type"],
+        width=response["width"],
+        height=response["height"],
     )
 
 
@@ -59,7 +56,6 @@ class PillowThumbnailGenerator(ThumbnailGenerator):
     ):
         self.max_pixels = max_pixels
         self.memory_limit_bytes = memory_limit_bytes
-        self.last_worker_pid = None
 
     async def can_generate(self, content_type: str, filename: str) -> bool:
         return content_type in SUPPORTED_CONTENT_TYPES
@@ -96,6 +92,4 @@ class PillowThumbnailGenerator(ThumbnailGenerator):
             process.kill()
             await process.wait()
             raise
-        result, worker_pid = _parse_worker_response(stdout, process.returncode)
-        self.last_worker_pid = worker_pid
-        return result
+        return _parse_worker_response(stdout, process.returncode)

--- a/datasette_files/pillow_thumbnails.py
+++ b/datasette_files/pillow_thumbnails.py
@@ -56,7 +56,10 @@ def _run_worker(
     except (json.JSONDecodeError, UnicodeDecodeError):
         raise ThumbnailGenerationError("generation_failed")
     if not response.get("ok"):
-        raise ThumbnailGenerationError(response.get("reason", "generation_failed"))
+        raise ThumbnailGenerationError(
+            response.get("reason", "generation_failed"),
+            skipped=bool(response.get("skipped")),
+        )
     return (
         ThumbnailResult(
             thumb_bytes=thumbnail,

--- a/datasette_files/pillow_thumbnails.py
+++ b/datasette_files/pillow_thumbnails.py
@@ -3,7 +3,13 @@ import json
 import sys
 from typing import Optional
 
-from .base import ThumbnailGenerationError, ThumbnailGenerator, ThumbnailResult
+from .base import (
+    DEFAULT_THUMBNAIL_MAX_PIXELS,
+    DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES,
+    ThumbnailGenerationError,
+    ThumbnailGenerator,
+    ThumbnailResult,
+)
 
 SUPPORTED_CONTENT_TYPES = {
     "image/jpeg",
@@ -48,8 +54,8 @@ class PillowThumbnailGenerator(ThumbnailGenerator):
     def __init__(
         self,
         *,
-        max_pixels: int = 12_000_000,
-        memory_limit_bytes: int = 128 * 1024 * 1024,
+        max_pixels: int = DEFAULT_THUMBNAIL_MAX_PIXELS,
+        memory_limit_bytes: int = DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES,
     ):
         self.max_pixels = max_pixels
         self.memory_limit_bytes = memory_limit_bytes

--- a/datasette_files/pillow_thumbnails.py
+++ b/datasette_files/pillow_thumbnails.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import subprocess
 import sys
 from typing import Optional
 
@@ -15,41 +14,12 @@ SUPPORTED_CONTENT_TYPES = {
     "image/tiff",
 }
 
+_WORKER_COMMAND = [sys.executable, "-m", "datasette_files.pillow_worker"]
 
-def _run_worker(
-    file_bytes: bytes,
-    max_width: int,
-    max_height: int,
-    max_pixels: int,
-    memory_limit_bytes: int,
-    timeout_seconds: float,
-) -> tuple[ThumbnailResult, int]:
-    metadata = json.dumps(
-        {
-            "max_width": max_width,
-            "max_height": max_height,
-            "max_pixels": max_pixels,
-            "memory_limit_bytes": memory_limit_bytes,
-        },
-        separators=(",", ":"),
-    ).encode("utf-8")
-    process = subprocess.Popen(
-        [sys.executable, "-m", "datasette_files.pillow_worker"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    try:
-        stdout, _ = process.communicate(
-            metadata + b"\n" + file_bytes, timeout=timeout_seconds
-        )
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.communicate()
-        raise ThumbnailGenerationError("timeout")
 
+def _parse_worker_response(stdout: bytes, returncode) -> tuple[ThumbnailResult, int]:
     header, separator, thumbnail = stdout.partition(b"\n")
-    if process.returncode or not separator:
+    if returncode or not separator:
         raise ThumbnailGenerationError("generation_failed")
     try:
         response = json.loads(header)
@@ -80,11 +50,9 @@ class PillowThumbnailGenerator(ThumbnailGenerator):
         *,
         max_pixels: int = 12_000_000,
         memory_limit_bytes: int = 128 * 1024 * 1024,
-        timeout_seconds: float = 10.0,
     ):
         self.max_pixels = max_pixels
         self.memory_limit_bytes = memory_limit_bytes
-        self.timeout_seconds = timeout_seconds
         self.last_worker_pid = None
 
     async def can_generate(self, content_type: str, filename: str) -> bool:
@@ -98,14 +66,30 @@ class PillowThumbnailGenerator(ThumbnailGenerator):
         max_width: int = 200,
         max_height: int = 200,
     ) -> Optional[ThumbnailResult]:
-        result, worker_pid = await asyncio.to_thread(
-            _run_worker,
-            file_bytes,
-            max_width,
-            max_height,
-            self.max_pixels,
-            self.memory_limit_bytes,
-            self.timeout_seconds,
+        header = json.dumps(
+            {
+                "max_width": max_width,
+                "max_height": max_height,
+                "max_pixels": self.max_pixels,
+                "memory_limit_bytes": self.memory_limit_bytes,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        process = await asyncio.create_subprocess_exec(
+            *_WORKER_COMMAND,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
+        try:
+            stdout, _ = await process.communicate(header + b"\n" + file_bytes)
+        except asyncio.CancelledError:
+            # The coordinator's timeout (or a dropped request) cancelled this
+            # coroutine. The worker must not outlive it: its memory belongs to
+            # the concurrency slot that is about to be released.
+            process.kill()
+            await process.wait()
+            raise
+        result, worker_pid = _parse_worker_response(stdout, process.returncode)
         self.last_worker_pid = worker_pid
         return result

--- a/datasette_files/pillow_thumbnails.py
+++ b/datasette_files/pillow_thumbnails.py
@@ -1,7 +1,10 @@
-import io
+import asyncio
+import json
+import subprocess
+import sys
 from typing import Optional
 
-from .base import ThumbnailGenerator, ThumbnailResult
+from .base import ThumbnailGenerationError, ThumbnailGenerator, ThumbnailResult
 
 SUPPORTED_CONTENT_TYPES = {
     "image/jpeg",
@@ -13,8 +16,73 @@ SUPPORTED_CONTENT_TYPES = {
 }
 
 
+def _run_worker(
+    file_bytes: bytes,
+    max_width: int,
+    max_height: int,
+    max_pixels: int,
+    memory_limit_bytes: int,
+    timeout_seconds: float,
+) -> tuple[ThumbnailResult, int]:
+    metadata = json.dumps(
+        {
+            "max_width": max_width,
+            "max_height": max_height,
+            "max_pixels": max_pixels,
+            "memory_limit_bytes": memory_limit_bytes,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    process = subprocess.Popen(
+        [sys.executable, "-m", "datasette_files.pillow_worker"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        stdout, _ = process.communicate(
+            metadata + b"\n" + file_bytes, timeout=timeout_seconds
+        )
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.communicate()
+        raise ThumbnailGenerationError("timeout")
+
+    header, separator, thumbnail = stdout.partition(b"\n")
+    if process.returncode or not separator:
+        raise ThumbnailGenerationError("generation_failed")
+    try:
+        response = json.loads(header)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise ThumbnailGenerationError("generation_failed")
+    if not response.get("ok"):
+        raise ThumbnailGenerationError(response.get("reason", "generation_failed"))
+    return (
+        ThumbnailResult(
+            thumb_bytes=thumbnail,
+            content_type=response["content_type"],
+            width=response["width"],
+            height=response["height"],
+        ),
+        response["pid"],
+    )
+
+
 class PillowThumbnailGenerator(ThumbnailGenerator):
     name = "pillow"
+    version = "2"
+
+    def __init__(
+        self,
+        *,
+        max_pixels: int = 12_000_000,
+        memory_limit_bytes: int = 128 * 1024 * 1024,
+        timeout_seconds: float = 10.0,
+    ):
+        self.max_pixels = max_pixels
+        self.memory_limit_bytes = memory_limit_bytes
+        self.timeout_seconds = timeout_seconds
+        self.last_worker_pid = None
 
     async def can_generate(self, content_type: str, filename: str) -> bool:
         return content_type in SUPPORTED_CONTENT_TYPES
@@ -27,30 +95,14 @@ class PillowThumbnailGenerator(ThumbnailGenerator):
         max_width: int = 200,
         max_height: int = 200,
     ) -> Optional[ThumbnailResult]:
-        try:
-            from PIL import Image
-        except ImportError:
-            return None
-        try:
-            from PIL import ImageOps
-
-            img = Image.open(io.BytesIO(file_bytes))
-            img = ImageOps.exif_transpose(img)
-            img.thumbnail((max_width, max_height), Image.LANCZOS)
-            if img.mode in ("RGBA", "LA", "PA"):
-                out_format = "PNG"
-                out_content_type = "image/png"
-            else:
-                img = img.convert("RGB")
-                out_format = "JPEG"
-                out_content_type = "image/jpeg"
-            buf = io.BytesIO()
-            img.save(buf, format=out_format, quality=85)
-            return ThumbnailResult(
-                thumb_bytes=buf.getvalue(),
-                content_type=out_content_type,
-                width=img.size[0],
-                height=img.size[1],
-            )
-        except Exception:
-            return None
+        result, worker_pid = await asyncio.to_thread(
+            _run_worker,
+            file_bytes,
+            max_width,
+            max_height,
+            self.max_pixels,
+            self.memory_limit_bytes,
+            self.timeout_seconds,
+        )
+        self.last_worker_pid = worker_pid
+        return result

--- a/datasette_files/pillow_worker.py
+++ b/datasette_files/pillow_worker.py
@@ -6,7 +6,6 @@ followed by image bytes on stdin, then writes a JSON header and thumbnail bytes.
 
 import io
 import json
-import os
 import sys
 
 
@@ -36,14 +35,7 @@ def main() -> None:
 
         image = Image.open(io.BytesIO(file_bytes))
         if image.width * image.height > int(options["max_pixels"]):
-            _respond(
-                {
-                    "ok": False,
-                    "reason": "too_many_pixels",
-                    "skipped": True,
-                    "pid": os.getpid(),
-                }
-            )
+            _respond({"ok": False, "reason": "too_many_pixels", "skipped": True})
             return
         image = ImageOps.exif_transpose(image)
         image.thumbnail(
@@ -61,7 +53,6 @@ def main() -> None:
         _respond(
             {
                 "ok": True,
-                "pid": os.getpid(),
                 "content_type": output_content_type,
                 "width": image.width,
                 "height": image.height,
@@ -69,9 +60,9 @@ def main() -> None:
             output.getvalue(),
         )
     except MemoryError:
-        _respond({"ok": False, "reason": "memory_limit", "pid": os.getpid()})
+        _respond({"ok": False, "reason": "memory_limit"})
     except Exception:
-        _respond({"ok": False, "reason": "generation_failed", "pid": os.getpid()})
+        _respond({"ok": False, "reason": "generation_failed"})
 
 
 if __name__ == "__main__":

--- a/datasette_files/pillow_worker.py
+++ b/datasette_files/pillow_worker.py
@@ -36,7 +36,14 @@ def main() -> None:
 
         image = Image.open(io.BytesIO(file_bytes))
         if image.width * image.height > int(options["max_pixels"]):
-            _respond({"ok": False, "reason": "too_many_pixels", "pid": os.getpid()})
+            _respond(
+                {
+                    "ok": False,
+                    "reason": "too_many_pixels",
+                    "skipped": True,
+                    "pid": os.getpid(),
+                }
+            )
             return
         image = ImageOps.exif_transpose(image)
         image.thumbnail(

--- a/datasette_files/pillow_worker.py
+++ b/datasette_files/pillow_worker.py
@@ -1,0 +1,71 @@
+"""Resource-constrained Pillow thumbnail worker.
+
+This module is an internal subprocess entry point. It accepts one JSON header line
+followed by image bytes on stdin, then writes a JSON header and thumbnail bytes.
+"""
+
+import io
+import json
+import os
+import sys
+
+
+def _set_memory_limit(limit: int) -> None:
+    # RLIMIT_AS is reliable on Linux, where small Datasette deployments commonly
+    # run. macOS accounts shared mappings in ways that make this limit unusable.
+    if not sys.platform.startswith("linux") or not limit:
+        return
+    import resource
+
+    resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+
+
+def _respond(payload: dict, body: bytes = b"") -> None:
+    sys.stdout.buffer.write(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n" + body
+    )
+
+
+def main() -> None:
+    try:
+        options = json.loads(sys.stdin.buffer.readline())
+        _set_memory_limit(int(options["memory_limit_bytes"]))
+        file_bytes = sys.stdin.buffer.read()
+
+        from PIL import Image, ImageOps
+
+        image = Image.open(io.BytesIO(file_bytes))
+        if image.width * image.height > int(options["max_pixels"]):
+            _respond({"ok": False, "reason": "too_many_pixels", "pid": os.getpid()})
+            return
+        image = ImageOps.exif_transpose(image)
+        image.thumbnail(
+            (int(options["max_width"]), int(options["max_height"])), Image.LANCZOS
+        )
+        if image.mode in ("RGBA", "LA", "PA"):
+            output_format = "PNG"
+            output_content_type = "image/png"
+        else:
+            image = image.convert("RGB")
+            output_format = "JPEG"
+            output_content_type = "image/jpeg"
+        output = io.BytesIO()
+        image.save(output, format=output_format, quality=85)
+        _respond(
+            {
+                "ok": True,
+                "pid": os.getpid(),
+                "content_type": output_content_type,
+                "width": image.width,
+                "height": image.height,
+            },
+            output.getvalue(),
+        )
+    except MemoryError:
+        _respond({"ok": False, "reason": "memory_limit", "pid": os.getpid()})
+    except Exception:
+        _respond({"ok": False, "reason": "generation_failed", "pid": os.getpid()})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,13 @@ def upload_dir(tmp_path):
     return str(d)
 
 
-def _make_datasette(upload_dir, permissions=None, extra_sources=None, databases=None):
+def _make_datasette(
+    upload_dir,
+    permissions=None,
+    extra_sources=None,
+    databases=None,
+    plugin_options=None,
+):
     """Create a Datasette instance configured with file sources and optional permissions."""
     sources = {
         "test-uploads": {
@@ -25,13 +31,10 @@ def _make_datasette(upload_dir, permissions=None, extra_sources=None, databases=
     if extra_sources:
         sources.update(extra_sources)
 
-    config = {
-        "plugins": {
-            "datasette-files": {
-                "sources": sources,
-            }
-        },
-    }
+    plugin_config = {"sources": sources}
+    if plugin_options:
+        plugin_config.update(plugin_options)
+    config = {"plugins": {"datasette-files": plugin_config}}
     if permissions:
         config["permissions"] = permissions
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -91,6 +91,59 @@ async def test_filesystem_storage_configure(upload_dir):
         {"root": upload_dir, "max_file_size": 1234}, get_secret=None
     )
     assert configured.capabilities.max_file_size == 1234
+    # Only max_file_size may differ from the class-level capabilities
+    import dataclasses
+
+    for field in dataclasses.fields(configured.capabilities):
+        if field.name == "max_file_size":
+            continue
+        assert getattr(configured.capabilities, field.name) == getattr(
+            FilesystemStorage.capabilities, field.name
+        )
+
+
+@pytest.mark.asyncio
+async def test_configured_max_file_size_rejects_oversized_upload(upload_dir):
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-upload": True},
+        extra_sources={
+            "test-uploads": {
+                "storage": "filesystem",
+                "config": {"root": upload_dir, "max_file_size": 100},
+            }
+        },
+    )
+    content = b"x" * 200
+    prepare = await ds.client.post(
+        "/-/files/upload/test-uploads/-/prepare",
+        content=json.dumps(
+            {
+                "filename": "big.bin",
+                "content_type": "application/octet-stream",
+                "size": len(content),
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+    assert prepare.status_code == 200
+    token = prepare.json()["upload_token"]
+
+    upload = await ds.client.post(
+        "/-/files/upload/test-uploads/-/upload",
+        content=(
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="upload_token"\r\n'
+            b"\r\n" + token.encode() + b"\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="file"; filename="big.bin"\r\n'
+            b"Content-Type: application/octet-stream\r\n"
+            b"\r\n" + content + b"\r\n"
+            b"--boundary--\r\n"
+        ),
+        headers={"Content-Type": "multipart/form-data; boundary=boundary"},
+    )
+    assert upload.status_code != 200
 
 
 @pytest.mark.asyncio

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -86,6 +86,12 @@ async def test_filesystem_storage_configure(upload_dir):
     assert storage.capabilities.can_list is True
     assert storage.capabilities.requires_proxy_download is True
 
+    configured = FilesystemStorage()
+    await configured.configure(
+        {"root": upload_dir, "max_file_size": 1234}, get_secret=None
+    )
+    assert configured.capabilities.max_file_size == 1234
+
 
 @pytest.mark.asyncio
 async def test_filesystem_storage_receive_and_read(upload_dir):
@@ -160,6 +166,8 @@ async def test_startup_creates_tables(datasette_with_files):
     assert "datasette_files_sources" in tables
     assert "datasette_files" in tables
     assert "datasette_files_fts" in tables
+    assert "datasette_files_thumbnails" in tables
+    assert "datasette_files_thumbnail_failures" in tables
 
     # Check source was registered
     rows = (await db.execute("select * from datasette_files_sources")).rows

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -103,6 +103,26 @@ async def test_filesystem_storage_configure(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_ensure_column_adds_missing_column_once(datasette_with_files):
+    from datasette_files import _ensure_column
+
+    ds = datasette_with_files
+    await ds.invoke_startup()
+    db = ds.get_internal_database()
+    await db.execute_write("CREATE TABLE migration_demo (id INTEGER PRIMARY KEY)")
+
+    await _ensure_column(db, "migration_demo", "extra", "TEXT DEFAULT ''")
+    # Idempotent: a second call must not raise
+    await _ensure_column(db, "migration_demo", "extra", "TEXT DEFAULT ''")
+
+    columns = {
+        row["name"]
+        for row in (await db.execute("PRAGMA table_info(migration_demo)")).rows
+    }
+    assert columns == {"id", "extra"}
+
+
+@pytest.mark.asyncio
 async def test_configured_max_file_size_rejects_oversized_upload(upload_dir):
     ds = _make_datasette(
         upload_dir,

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -553,7 +553,9 @@ async def test_thumbnail_eager_generation_can_be_disabled(upload_dir):
 
 
 @pytest.mark.asyncio
-async def test_failed_generation_is_cached_and_generator_version_invalidates(upload_dir):
+async def test_failed_generation_is_cached_and_generator_version_invalidates(
+    upload_dir,
+):
     from datasette import hookimpl
     from datasette.plugins import pm
 
@@ -699,10 +701,16 @@ async def test_thumbnail_generation_is_serialized_by_default(upload_dir):
             plugin_options={"thumbnail_eager": False},
         )
         one = await _upload_file(
-            ds, filename="one.bin", content=b"1", content_type="application/x-concurrency"
+            ds,
+            filename="one.bin",
+            content=b"1",
+            content_type="application/x-concurrency",
         )
         two = await _upload_file(
-            ds, filename="two.bin", content=b"2", content_type="application/x-concurrency"
+            ds,
+            filename="two.bin",
+            content=b"2",
+            content_type="application/x-concurrency",
         )
         await asyncio.gather(
             ds.client.get(f"/-/files/{one['file_id']}/thumbnail"),
@@ -1115,8 +1123,6 @@ async def test_pillow_generation_runs_in_an_isolated_process(monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", spying_exec)
     generator = PillowThumbnailGenerator()
-    result = await generator.generate(
-        _make_test_jpeg(), "image/jpeg", "isolated.jpg"
-    )
+    result = await generator.generate(_make_test_jpeg(), "image/jpeg", "isolated.jpg")
     assert result is not None
     assert spawned and "datasette_files.pillow_worker" in spawned[0]

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -1,4 +1,6 @@
+import asyncio
 import io
+import os
 import pytest
 from PIL import Image
 from conftest import _make_datasette, _upload_file
@@ -445,3 +447,270 @@ async def test_thumbnail_deleted_with_file(datasette_all_permissions, upload_dir
         )
     ).first()
     assert row is None
+
+
+# --- Group 7: Resource safety policies ---
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_skips_source_larger_than_configured_limit(upload_dir):
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={
+            "thumbnail_eager": False,
+            "thumbnail_max_source_bytes": 100,
+        },
+    )
+    data = await _upload_file(
+        ds,
+        filename="large.jpg",
+        content=_make_test_jpeg(),
+        content_type="image/jpeg",
+    )
+
+    response = await ds.client.get(f"/-/files/{data['file_id']}/thumbnail")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/svg+xml"
+    row = (
+        await ds.get_internal_database().execute(
+            "SELECT status, reason FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+            [data["file_id"]],
+        )
+    ).first()
+    assert dict(row) == {"status": "skipped", "reason": "too_large"}
+
+
+@pytest.mark.asyncio
+async def test_filesystem_bounded_read_rejects_actual_oversize_file(tmp_path):
+    from datasette_files.base import FileTooLarge
+    from datasette_files.filesystem import FilesystemStorage
+
+    storage = FilesystemStorage()
+    await storage.configure({"root": str(tmp_path)}, get_secret=None)
+    (tmp_path / "large.bin").write_bytes(b"x" * 101)
+    with pytest.raises(FileTooLarge):
+        await storage.read_file_limited("large.bin", 100)
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_rejects_image_over_pixel_limit(upload_dir):
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={
+            "thumbnail_eager": False,
+            "thumbnail_max_pixels": 10_000,
+        },
+    )
+    data = await _upload_file(
+        ds,
+        filename="many-pixels.jpg",
+        content=_make_test_jpeg(200, 200),
+        content_type="image/jpeg",
+    )
+
+    response = await ds.client.get(f"/-/files/{data['file_id']}/thumbnail")
+    assert response.headers["content-type"] == "image/svg+xml"
+    row = (
+        await ds.get_internal_database().execute(
+            "SELECT reason FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+            [data["file_id"]],
+        )
+    ).first()
+    assert row["reason"] == "too_many_pixels"
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_eager_generation_can_be_disabled(upload_dir):
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={"thumbnail_eager": False},
+    )
+    data = await _upload_file(
+        ds,
+        filename="lazy.jpg",
+        content=_make_test_jpeg(),
+        content_type="image/jpeg",
+    )
+    row = (
+        await ds.get_internal_database().execute(
+            "SELECT file_id FROM datasette_files_thumbnails WHERE file_id = ?",
+            [data["file_id"]],
+        )
+    ).first()
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_failed_generation_is_cached_and_generator_version_invalidates(upload_dir):
+    from datasette import hookimpl
+    from datasette.plugins import pm
+
+    calls = 0
+
+    class FailingPlugin:
+        __name__ = "FailingThumbnailPlugin"
+
+        @hookimpl
+        def register_thumbnail_generators(self, datasette):
+            class FailingGenerator:
+                name = "failing"
+                version = "1"
+
+                async def can_generate(self, content_type, filename):
+                    return content_type == "application/x-failing"
+
+                async def generate(self, *args, **kwargs):
+                    nonlocal calls
+                    calls += 1
+                    return None
+
+            self.generator = FailingGenerator()
+            return [self.generator]
+
+    plugin = FailingPlugin()
+    pm.register(plugin, name="undo_FailingThumbnailPlugin")
+    try:
+        ds = _make_datasette(
+            upload_dir,
+            permissions={"files-browse": True, "files-upload": True},
+            plugin_options={"thumbnail_eager": False},
+        )
+        data = await _upload_file(
+            ds,
+            filename="bad.fail",
+            content=b"not renderable",
+            content_type="application/x-failing",
+        )
+        url = f"/-/files/{data['file_id']}/thumbnail"
+        await ds.client.get(url)
+        await ds.client.get(url)
+        assert calls == 1
+
+        plugin.generator.version = "2"
+        await ds.client.get(url)
+        assert calls == 2
+    finally:
+        pm.unregister(name="undo_FailingThumbnailPlugin")
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_generation_timeout_is_negatively_cached(upload_dir):
+    from datasette import hookimpl
+    from datasette.plugins import pm
+
+    calls = 0
+
+    class SlowPlugin:
+        __name__ = "SlowThumbnailPlugin"
+
+        @hookimpl
+        def register_thumbnail_generators(self, datasette):
+            class SlowGenerator:
+                name = "slow"
+
+                async def can_generate(self, content_type, filename):
+                    return content_type == "application/x-slow"
+
+                async def generate(self, *args, **kwargs):
+                    nonlocal calls
+                    calls += 1
+                    await asyncio.sleep(0.2)
+
+            return [SlowGenerator()]
+
+    pm.register(SlowPlugin(), name="undo_SlowThumbnailPlugin")
+    try:
+        ds = _make_datasette(
+            upload_dir,
+            permissions={"files-browse": True, "files-upload": True},
+            plugin_options={
+                "thumbnail_eager": False,
+                "thumbnail_timeout_seconds": 0.01,
+            },
+        )
+        data = await _upload_file(
+            ds,
+            filename="slow.bin",
+            content=b"slow",
+            content_type="application/x-slow",
+        )
+        url = f"/-/files/{data['file_id']}/thumbnail"
+        response = await ds.client.get(url)
+        assert response.headers["content-type"] == "image/svg+xml"
+        await ds.client.get(url)
+        assert calls == 1
+        row = (
+            await ds.get_internal_database().execute(
+                "SELECT reason FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                [data["file_id"]],
+            )
+        ).first()
+        assert row["reason"] == "timeout"
+    finally:
+        pm.unregister(name="undo_SlowThumbnailPlugin")
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_generation_is_serialized_by_default(upload_dir):
+    from datasette import hookimpl
+    from datasette.plugins import pm
+
+    active = 0
+    maximum_active = 0
+
+    class ConcurrencyPlugin:
+        __name__ = "ConcurrencyThumbnailPlugin"
+
+        @hookimpl
+        def register_thumbnail_generators(self, datasette):
+            class ConcurrencyGenerator:
+                name = "concurrency"
+
+                async def can_generate(self, content_type, filename):
+                    return content_type == "application/x-concurrency"
+
+                async def generate(self, *args, **kwargs):
+                    nonlocal active, maximum_active
+                    active += 1
+                    maximum_active = max(maximum_active, active)
+                    await asyncio.sleep(0.05)
+                    active -= 1
+                    return None
+
+            return [ConcurrencyGenerator()]
+
+    pm.register(ConcurrencyPlugin(), name="undo_ConcurrencyThumbnailPlugin")
+    try:
+        ds = _make_datasette(
+            upload_dir,
+            permissions={"files-browse": True, "files-upload": True},
+            plugin_options={"thumbnail_eager": False},
+        )
+        one = await _upload_file(
+            ds, filename="one.bin", content=b"1", content_type="application/x-concurrency"
+        )
+        two = await _upload_file(
+            ds, filename="two.bin", content=b"2", content_type="application/x-concurrency"
+        )
+        await asyncio.gather(
+            ds.client.get(f"/-/files/{one['file_id']}/thumbnail"),
+            ds.client.get(f"/-/files/{two['file_id']}/thumbnail"),
+        )
+        assert maximum_active == 1
+    finally:
+        pm.unregister(name="undo_ConcurrencyThumbnailPlugin")
+
+
+@pytest.mark.asyncio
+async def test_pillow_generation_runs_in_an_isolated_process():
+    from datasette_files.pillow_thumbnails import PillowThumbnailGenerator
+
+    generator = PillowThumbnailGenerator()
+    result = await generator.generate(
+        _make_test_jpeg(), "image/jpeg", "isolated.jpg"
+    )
+    assert result is not None
+    assert generator.last_worker_pid != os.getpid()

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -337,12 +337,15 @@ async def test_thumbnail_is_cached_in_database(datasette_browse_allowed, upload_
 
 @pytest.mark.asyncio
 async def test_thumbnail_generated_on_upload(datasette_browse_allowed, upload_dir):
+    from datasette_files import _drain_eager_thumbnails
+
     ds = datasette_browse_allowed
     jpeg_bytes = _make_test_jpeg()
     data = await _upload_file(
         ds, filename="eager.jpg", content=jpeg_bytes, content_type="image/jpeg"
     )
     file_id = data["file_id"]
+    await _drain_eager_thumbnails()
 
     # Thumbnail should already be in the database (eager generation)
     db = ds.get_internal_database()
@@ -403,6 +406,9 @@ async def test_thumbnail_generated_on_upload_for_non_image_generator(upload_dir)
             content_type="application/pdf",
         )
         file_id = data["file_id"]
+        from datasette_files import _drain_eager_thumbnails
+
+        await _drain_eager_thumbnails()
 
         db = ds.get_internal_database()
         row = (
@@ -425,12 +431,15 @@ async def test_thumbnail_generated_on_upload_for_non_image_generator(upload_dir)
 
 @pytest.mark.asyncio
 async def test_thumbnail_deleted_with_file(datasette_all_permissions, upload_dir):
+    from datasette_files import _drain_eager_thumbnails
+
     ds = datasette_all_permissions
     jpeg_bytes = _make_test_jpeg(100, 100)
     data = await _upload_file(
         ds, filename="todelete.jpg", content=jpeg_bytes, content_type="image/jpeg"
     )
     file_id = data["file_id"]
+    await _drain_eager_thumbnails()
 
     # Generate thumbnail
     await ds.client.get(f"/-/files/{file_id}/thumbnail")
@@ -883,6 +892,7 @@ async def test_existing_thumbnails_survive_upgrade_migration(upload_dir):
         content_type="image/jpeg",
     )
     file_id = data["file_id"]
+    await datasette_files._drain_eager_thumbnails()
     db = ds.get_internal_database()
 
     # Simulate a database created before cache keys existed, holding a file
@@ -991,6 +1001,42 @@ async def test_thumbnail_generated_when_recorded_size_is_unknown(upload_dir):
     response = await ds.client.get(f"/-/files/{data['file_id']}/thumbnail")
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_upload_response_not_blocked_by_thumbnail_queue(upload_dir):
+    import datasette_files
+
+    ds = _make_datasette(
+        upload_dir, permissions={"files-browse": True, "files-upload": True}
+    )
+    await ds.invoke_startup()
+    state = datasette_files._thumbnail_state(ds)
+
+    # Simulate another request occupying the single generation slot
+    await state.semaphore.acquire()
+    try:
+        data = await asyncio.wait_for(
+            _upload_file(
+                ds,
+                filename="queued.jpg",
+                content=_make_test_jpeg(),
+                content_type="image/jpeg",
+            ),
+            timeout=2.0,
+        )
+    finally:
+        state.semaphore.release()
+
+    # The deferred eager generation still completes once the slot frees
+    await datasette_files._drain_eager_thumbnails()
+    row = (
+        await ds.get_internal_database().execute(
+            "SELECT file_id FROM datasette_files_thumbnails WHERE file_id = ?",
+            [data["file_id"]],
+        )
+    ).first()
+    assert row is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -948,6 +948,22 @@ async def test_thumbnail_settings_are_per_instance(upload_dir, tmp_path):
     assert dict(row) == {"status": "skipped", "reason": "too_large"}
 
 
+def test_thumbnail_safety_defaults_are_shared():
+    from datasette_files import ThumbnailSettings, base
+    from datasette_files.pillow_thumbnails import PillowThumbnailGenerator
+
+    generator = PillowThumbnailGenerator()
+    assert generator.max_pixels == base.DEFAULT_THUMBNAIL_MAX_PIXELS
+    assert generator.memory_limit_bytes == base.DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES
+
+    settings = ThumbnailSettings()
+    assert settings.max_source_bytes == base.DEFAULT_THUMBNAIL_MAX_SOURCE_BYTES
+    assert settings.max_pixels == base.DEFAULT_THUMBNAIL_MAX_PIXELS
+    assert settings.concurrency == base.DEFAULT_THUMBNAIL_CONCURRENCY
+    assert settings.timeout_seconds == base.DEFAULT_THUMBNAIL_TIMEOUT_SECONDS
+    assert settings.memory_limit_bytes == base.DEFAULT_THUMBNAIL_MEMORY_LIMIT_BYTES
+
+
 @pytest.mark.asyncio
 async def test_read_file_limited_default_reads_when_size_unknown():
     from datasette_files.base import (

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -823,6 +823,53 @@ async def test_cached_thumbnail_outcome_needs_a_single_cache_query(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_generator_can_mark_failure_as_policy_skip(upload_dir):
+    from datasette import hookimpl
+    from datasette.plugins import pm
+    from datasette_files.base import ThumbnailGenerationError
+
+    class SkippingPlugin:
+        __name__ = "SkippingThumbnailPlugin"
+
+        @hookimpl
+        def register_thumbnail_generators(self, datasette):
+            class SkippingGenerator:
+                name = "skipping"
+
+                async def can_generate(self, content_type, filename):
+                    return content_type == "application/x-skip"
+
+                async def generate(self, *args, **kwargs):
+                    raise ThumbnailGenerationError("wrong_colorspace", skipped=True)
+
+            return [SkippingGenerator()]
+
+    pm.register(SkippingPlugin(), name="undo_SkippingThumbnailPlugin")
+    try:
+        ds = _make_datasette(
+            upload_dir,
+            permissions={"files-browse": True, "files-upload": True},
+            plugin_options={"thumbnail_eager": False},
+        )
+        data = await _upload_file(
+            ds,
+            filename="skip.bin",
+            content=b"skip",
+            content_type="application/x-skip",
+        )
+        await ds.client.get(f"/-/files/{data['file_id']}/thumbnail")
+        row = (
+            await ds.get_internal_database().execute(
+                "SELECT status, reason FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+                [data["file_id"]],
+            )
+        ).first()
+        assert dict(row) == {"status": "skipped", "reason": "wrong_colorspace"}
+    finally:
+        pm.unregister(name="undo_SkippingThumbnailPlugin")
+
+
+@pytest.mark.asyncio
 async def test_read_file_limited_default_reads_when_size_unknown():
     from datasette_files.base import (
         FileMetadata,

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -790,6 +790,39 @@ async def test_failed_generation_is_retried_after_cooldown(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_cached_thumbnail_outcome_needs_a_single_cache_query(upload_dir):
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={"thumbnail_eager": False},
+    )
+    data = await _upload_file(
+        ds, filename="doc.txt", content=b"hello", content_type="text/plain"
+    )
+    url = f"/-/files/{data['file_id']}/thumbnail"
+    # First request caches the skipped/unsupported outcome
+    await ds.client.get(url)
+
+    db = ds.get_internal_database()
+    executed = []
+    original_execute = db.execute
+
+    def spying_execute(sql, *args, **kwargs):
+        executed.append(sql)
+        return original_execute(sql, *args, **kwargs)
+
+    db.execute = spying_execute
+    try:
+        response = await ds.client.get(url)
+    finally:
+        db.execute = original_execute
+
+    assert response.headers["content-type"] == "image/svg+xml"
+    cache_queries = [sql for sql in executed if "datasette_files_thumbnail" in sql]
+    assert len(cache_queries) == 1
+
+
+@pytest.mark.asyncio
 async def test_read_file_limited_default_reads_when_size_unknown():
     from datasette_files.base import (
         FileMetadata,

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -705,6 +705,61 @@ async def test_thumbnail_generation_is_serialized_by_default(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_read_file_limited_default_reads_when_size_unknown():
+    from datasette_files.base import (
+        FileMetadata,
+        FileTooLarge,
+        Storage,
+        StorageCapabilities,
+    )
+
+    class UnknownSizeStorage(Storage):
+        storage_type = "unknown-size"
+        capabilities = StorageCapabilities()
+        content = b"tiny"
+
+        async def configure(self, config, get_secret):
+            pass
+
+        async def get_file_metadata(self, path):
+            return FileMetadata(path=path, filename=path)
+
+        async def read_file(self, path):
+            return self.content
+
+    storage = UnknownSizeStorage()
+    assert await storage.read_file_limited("small.jpg", 100) == b"tiny"
+
+    oversized = UnknownSizeStorage()
+    oversized.content = b"x" * 101
+    with pytest.raises(FileTooLarge):
+        await oversized.read_file_limited("large.jpg", 100)
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_generated_when_recorded_size_is_unknown(upload_dir):
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={"thumbnail_eager": False},
+    )
+    data = await _upload_file(
+        ds,
+        filename="nosize.jpg",
+        content=_make_test_jpeg(),
+        content_type="image/jpeg",
+    )
+    db = ds.get_internal_database()
+    await db.execute_write(
+        "UPDATE datasette_files SET size = NULL WHERE id = ?", [data["file_id"]]
+    )
+
+    response = await ds.client.get(f"/-/files/{data['file_id']}/thumbnail")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+
+
+@pytest.mark.asyncio
 async def test_pillow_generation_runs_in_an_isolated_process():
     from datasette_files.pillow_thumbnails import PillowThumbnailGenerator
 

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -994,6 +994,53 @@ async def test_thumbnail_generated_when_recorded_size_is_unknown(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_cancelled_generation_kills_worker_process(monkeypatch, tmp_path):
+    import sys
+    from datasette_files import pillow_thumbnails
+
+    pid_file = tmp_path / "worker.pid"
+    fake_worker = (
+        "import os, sys, time\n"
+        f"open({str(pid_file)!r}, 'w').write(str(os.getpid()))\n"
+        "sys.stdin.buffer.read()\n"
+        "time.sleep(30)\n"
+    )
+    monkeypatch.setattr(
+        pillow_thumbnails,
+        "_WORKER_COMMAND",
+        [sys.executable, "-c", fake_worker],
+        raising=False,
+    )
+
+    generator = pillow_thumbnails.PillowThumbnailGenerator()
+    task = asyncio.create_task(generator.generate(b"x", "image/jpeg", "slow.jpg"))
+    for _ in range(200):
+        if pid_file.exists() and pid_file.read_text():
+            break
+        await asyncio.sleep(0.05)
+    else:
+        task.cancel()
+        pytest.fail("worker subprocess never started")
+    pid = int(pid_file.read_text())
+
+    # This is what the coordinator's timeout does to a slow generator
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The worker must not outlive the cancelled request
+    for _ in range(100):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            break
+        await asyncio.sleep(0.05)
+    else:
+        os.kill(pid, 9)
+        pytest.fail("worker subprocess survived cancellation")
+
+
+@pytest.mark.asyncio
 async def test_pillow_generation_runs_in_an_isolated_process():
     from datasette_files.pillow_thumbnails import PillowThumbnailGenerator
 

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -904,6 +904,41 @@ async def test_existing_thumbnails_survive_upgrade_migration(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_thumbnail_settings_are_per_instance(upload_dir, tmp_path):
+    strict = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={
+            "thumbnail_eager": False,
+            "thumbnail_max_source_bytes": 100,
+        },
+    )
+    data = await _upload_file(
+        strict,
+        filename="big.jpg",
+        content=_make_test_jpeg(),
+        content_type="image/jpeg",
+    )
+
+    # Starting a second instance in the same process must not affect the first
+    other = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+    )
+    await other.invoke_startup()
+
+    response = await strict.client.get(f"/-/files/{data['file_id']}/thumbnail")
+    assert response.headers["content-type"] == "image/svg+xml"
+    row = (
+        await strict.get_internal_database().execute(
+            "SELECT status, reason FROM datasette_files_thumbnail_failures WHERE file_id = ?",
+            [data["file_id"]],
+        )
+    ).first()
+    assert dict(row) == {"status": "skipped", "reason": "too_large"}
+
+
+@pytest.mark.asyncio
 async def test_read_file_limited_default_reads_when_size_unknown():
     from datasette_files.base import (
         FileMetadata,

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -870,6 +870,40 @@ async def test_generator_can_mark_failure_as_policy_skip(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_existing_thumbnails_survive_upgrade_migration(upload_dir):
+    import datasette_files
+
+    ds = _make_datasette(
+        upload_dir, permissions={"files-browse": True, "files-upload": True}
+    )
+    data = await _upload_file(
+        ds,
+        filename="legacy.jpg",
+        content=_make_test_jpeg(),
+        content_type="image/jpeg",
+    )
+    file_id = data["file_id"]
+    db = ds.get_internal_database()
+
+    # Simulate a database created before cache keys existed, holding a file
+    # the new limits would refuse to regenerate
+    await db.execute_write(
+        "UPDATE datasette_files_thumbnails SET cache_key = NULL WHERE file_id = ?",
+        [file_id],
+    )
+    await db.execute_write(
+        "UPDATE datasette_files SET size = 999999999 WHERE id = ?", [file_id]
+    )
+
+    # Simulate a restart against the existing database
+    await datasette_files.startup(ds)()
+
+    response = await ds.client.get(f"/-/files/{file_id}/thumbnail")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+
+
+@pytest.mark.asyncio
 async def test_read_file_limited_default_reads_when_size_unknown():
     from datasette_files.base import (
         FileMetadata,

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -705,6 +705,91 @@ async def test_thumbnail_generation_is_serialized_by_default(upload_dir):
 
 
 @pytest.mark.asyncio
+async def test_missing_source_does_not_permanently_break_thumbnails(upload_dir):
+    import datasette_files
+
+    ds = _make_datasette(
+        upload_dir,
+        permissions={"files-browse": True, "files-upload": True},
+        plugin_options={"thumbnail_eager": False},
+    )
+    data = await _upload_file(
+        ds,
+        filename="transient.jpg",
+        content=_make_test_jpeg(),
+        content_type="image/jpeg",
+    )
+    url = f"/-/files/{data['file_id']}/thumbnail"
+
+    # Simulate the source being temporarily unavailable (e.g. removed from config)
+    storage = datasette_files._sources.pop("test-uploads")
+    try:
+        response = await ds.client.get(url)
+        assert response.headers["content-type"] == "image/svg+xml"
+    finally:
+        datasette_files._sources["test-uploads"] = storage
+
+    # Once the source is back, thumbnails should generate again
+    response = await ds.client.get(url)
+    assert response.headers["content-type"] == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_failed_generation_is_retried_after_cooldown(upload_dir):
+    from datasette import hookimpl
+    from datasette.plugins import pm
+
+    calls = 0
+
+    class FlakyPlugin:
+        __name__ = "FlakyThumbnailPlugin"
+
+        @hookimpl
+        def register_thumbnail_generators(self, datasette):
+            class FlakyGenerator:
+                name = "flaky"
+
+                async def can_generate(self, content_type, filename):
+                    return content_type == "application/x-flaky"
+
+                async def generate(self, *args, **kwargs):
+                    nonlocal calls
+                    calls += 1
+                    raise RuntimeError("transient failure")
+
+            return [FlakyGenerator()]
+
+    pm.register(FlakyPlugin(), name="undo_FlakyThumbnailPlugin")
+    try:
+        ds = _make_datasette(
+            upload_dir,
+            permissions={"files-browse": True, "files-upload": True},
+            plugin_options={"thumbnail_eager": False},
+        )
+        data = await _upload_file(
+            ds,
+            filename="flaky.bin",
+            content=b"flaky",
+            content_type="application/x-flaky",
+        )
+        url = f"/-/files/{data['file_id']}/thumbnail"
+        await ds.client.get(url)
+        await ds.client.get(url)
+        assert calls == 1  # Within the cooldown the failure stays cached
+
+        # Backdate the failure past the retry cooldown
+        await ds.get_internal_database().execute_write(
+            """UPDATE datasette_files_thumbnail_failures
+               SET created_at = datetime('now', '-1 hour') WHERE file_id = ?""",
+            [data["file_id"]],
+        )
+        await ds.client.get(url)
+        assert calls == 2
+    finally:
+        pm.unregister(name="undo_FlakyThumbnailPlugin")
+
+
+@pytest.mark.asyncio
 async def test_read_file_limited_default_reads_when_size_unknown():
     from datasette_files.base import (
         FileMetadata,

--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -1103,12 +1103,20 @@ async def test_cancelled_generation_kills_worker_process(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_pillow_generation_runs_in_an_isolated_process():
+async def test_pillow_generation_runs_in_an_isolated_process(monkeypatch):
     from datasette_files.pillow_thumbnails import PillowThumbnailGenerator
 
+    spawned = []
+    real_exec = asyncio.create_subprocess_exec
+
+    async def spying_exec(*args, **kwargs):
+        spawned.append(args)
+        return await real_exec(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spying_exec)
     generator = PillowThumbnailGenerator()
     result = await generator.generate(
         _make_test_jpeg(), "image/jpeg", "isolated.jpg"
     )
     assert result is not None
-    assert generator.last_worker_pid != os.getpid()
+    assert spawned and "datasette_files.pillow_worker" in spawned[0]


### PR DESCRIPTION
## Summary

- cap thumbnail source bytes and decoded image pixels
- serialize generation and isolate Pillow in a resource-limited subprocess
- cache failures with generator/policy version invalidation
- add configurable eager generation, timeouts, and filesystem bounded reads
- document safety defaults for small-memory deployments

## Why

Thumbnail generation previously loaded an entire source file into the Datasette process. A large or highly compressed image could exhaust memory on a 256 MB instance.

## Impact

The defaults now limit sources to 10 MB and decoded images to 12 megapixels, run one generation at a time, and fall back to the existing SVG icon when work is unsafe or fails.

Codex: https://gist.github.com/simonw/de8932fcf19244c44b653aef163fa771